### PR TITLE
fix: AuthControllerTest의 로그아웃 API 엔드포인트 수정

### DIFF
--- a/backend/demo/src/test/java/com/sesac/solbid/controller/AuthControllerTest.java
+++ b/backend/demo/src/test/java/com/sesac/solbid/controller/AuthControllerTest.java
@@ -206,7 +206,7 @@ class AuthControllerTest {
     @DisplayName("로그아웃 성공")
     void logout_Success() throws Exception {
         // When & Then
-        mockMvc.perform(post("/api/auth/oauth2/logout")
+        mockMvc.perform(post("/api/auth/logout")
                         .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -616,12 +616,12 @@ class AuthControllerTest {
     @DisplayName("로그아웃 - 이미 로그아웃된 상태에서 재요청")
     void logout_AlreadyLoggedOut() throws Exception {
         // When & Then - 여러 번 로그아웃 요청해도 성공
-        mockMvc.perform(post("/api/auth/oauth2/logout")
+        mockMvc.perform(post("/api/auth/logout")
                         .with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true));
 
-        mockMvc.perform(post("/api/auth/oauth2/logout")
+        mockMvc.perform(post("/api/auth/logout")
                         .with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true));


### PR DESCRIPTION
**관련 이슈**

- closes #52 

AuthController의 API 엔드포인트 구조가 변경됨에 따라, 이에 영향을 받는 AuthControllerTest의 로그아웃 테스트 API 호출 경로를 수정했습니다.