### PR TITLE
chore: dev 브랜치 PR 병합 시 이슈 자동 닫기 워크플로우 추가

### DIFF
--- a/.github/workflows/auto-close-issue.yml
+++ b/.github/workflows/auto-close-issue.yml
@@ -1,0 +1,21 @@
+# 워크플로우 이름
+name: Auto Close Issue on Dev Merge
+
+# 실행 조건: pull_request가 닫혔을 때 실행
+on:
+  pull_request:
+    types:
+      - closed
+
+# 실행할 작업들
+jobs:
+  close-issue:
+    # 'dev' 브랜치로 병합(merged)된 경우에만 실행
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'dev'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close linked issue
+        uses: peter-evans/close-issue@v3
+        with:
+          close-message: '개발 브랜치에 병합되어 이슈를 닫습니다. (Closed by PR)'
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 관련 이슈

- closes #69 

## 작업 내용
- `.github/workflows/auto-close-issue.yml` 워크플로우 파일을 추가했습니다.
- 워크플로우는 `dev` 브랜치에 PR이 병합될 때마다 실행됩니다.
- `peter-evans/close-issue` 액션을 사용하여 PR 본문의 키워드를 통해 연결된 이슈를 자동으로 닫습니다.