### PR TITLE
feat: 결제내역 조회 페이지 서버 연동 및 필터/페이징/상세 구현

### DIFF
--- a/backend/demo/src/main/java/com/sesac/solbid/repository/PaymentsRepository.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/repository/PaymentsRepository.java
@@ -36,7 +36,7 @@ public interface PaymentsRepository extends JpaRepository<Payments, Long>, JpaSp
 
     //포인트 전환건만 조회, 필터 활성 user 예약어 이슈 회피
     @Query(value = """
-        SELECT new com.sesac.solbid.dto.response.PaymentRecordItemResponse(
+        SELECT new com.sesac.solbid.dto.payment.response.PaymentRecordItemResponse(
             p.paymentId, u.userId, p.orderId, p.transactionId, p.amount,
             p.paymentMethod, p.provider, p.paymentStatus, p.charged,
             p.convertedPoint, p.requestedAt, p.confirmedAt

--- a/frontend/src/features/payment/components/DetailModal.tsx
+++ b/frontend/src/features/payment/components/DetailModal.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import type { Payment } from '../types/payment';
+
+interface DetailModalProps {
+    payment: Payment;
+    onClose: () => void;
+}
+
+const fmtDateTime = (s?: string | null) =>
+    s ? s.replace('T', ' ').slice(0, 16) : '-';
+
+const DetailModal: React.FC<DetailModalProps> = ({ payment, onClose }) => {
+    return (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+            <div className="bg-white rounded-lg p-6 max-w-2xl w-full mx-4">
+                <div className="flex justify-between items-center mb-6">
+                    <h3 className="text-lg font-semibold text-gray-900">결제 상세 정보</h3>
+                    <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+                        <i className="fas fa-times" />
+                    </button>
+                </div>
+
+                <div className="space-y-6">
+                    <div className="grid grid-cols-2 gap-4">
+                        <div>
+                            <div className="text-sm font-medium text-gray-500">결제일시</div>
+                            <div className="mt-1 text-sm text-gray-900">
+                                {fmtDateTime(payment.confirmedAt ?? payment.requestedAt)}
+                            </div>
+                        </div>
+                        <div>
+                            <div className="text-sm font-medium text-gray-500">결제금액</div>
+                            <div className="mt-1 text-sm text-gray-900">{payment.amount.toLocaleString('ko-KR')}원</div>
+                        </div>
+                        <div>
+                            <div className="text-sm font-medium text-gray-500">전환된 포인트</div>
+                            <div className="mt-1 text-sm font-medium text-blue-600">
+                                +{payment.convertedPoint.toLocaleString('ko-KR')}P
+                            </div>
+                        </div>
+                        <div>
+                            <div className="text-sm font-medium text-gray-500">결제수단</div>
+                            <div className="mt-1 text-sm text-gray-900">{payment.method}</div>
+                        </div>
+                        <div>
+                            <div className="text-sm font-medium text-gray-500">주문번호</div>
+                            <div className="mt-1 text-sm text-gray-900">{payment.orderId}</div>
+                        </div>
+                        <div>
+                            <div className="text-sm font-medium text-gray-500">거래 ID</div>
+                            <div className="mt-1 text-sm text-gray-900">{payment.transactionId}</div>
+                        </div>
+                    </div>
+
+                    <div className="border-t pt-6">
+                        <button className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 !rounded-button whitespace-nowrap">
+                            <i className="fas fa-download mr-2" />
+                            영수증 다운로드
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default DetailModal;

--- a/frontend/src/features/payment/components/FiltersBar.tsx
+++ b/frontend/src/features/payment/components/FiltersBar.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import type { DateFilter, PaymentTableFilter } from '../types/payment';
+
+interface Props {
+    dateFilter: DateFilter;
+    setDateFilter: React.Dispatch<React.SetStateAction<DateFilter>>;
+    searchTerm: string;
+    setSearchTerm: React.Dispatch<React.SetStateAction<string>>;
+    paymentStatus: PaymentTableFilter;
+    setPaymentStatus: React.Dispatch<React.SetStateAction<PaymentTableFilter>>;
+}
+
+const FiltersBar: React.FC<Props> = ({
+                                         dateFilter, setDateFilter, searchTerm, setSearchTerm, paymentStatus, setPaymentStatus,
+                                     }) => {
+    return (
+        <div className="flex flex-wrap gap-4 mb-6">
+            {/* 기간 */}
+            <div className="flex-1 min-w-[300px]">
+                <div className="flex space-x-2">
+                    {([
+                        { key: 'today', label: '오늘' },
+                        { key: '1week', label: '1주일' },
+                        { key: '1month', label: '1개월' },
+                        { key: '3months', label: '3개월' },
+                    ] as { key: DateFilter; label: string }[]).map(({ key, label }) => (
+                        <button
+                            key={key}
+                            onClick={() => setDateFilter(key)}
+                            className={`px-4 py-2 text-sm rounded-lg ${
+                                dateFilter === key ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700'
+                            } !rounded-button whitespace-nowrap`}
+                        >
+                            {label}
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            {/* 검색 */}
+            <div className="flex-1 min-w-[300px]">
+                <div className="relative">
+                    <input
+                        type="text"
+                        placeholder="결제수단 검색"
+                        value={searchTerm}
+                        onChange={(e) => setSearchTerm(e.target.value)}
+                        className="w-full pl-10 pr-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                    />
+                    <i className="fas fa-search absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+                </div>
+            </div>
+
+            {/* 상태 */}
+            <div className="flex items-center space-x-2">
+                {([
+                    { key: 'all', label: '전체' },
+                    { key: 'completed', label: '결제완료' },
+                    { key: 'cancelled', label: '결제취소' },
+                ] as { key: PaymentTableFilter; label: string }[]).map(({ key, label }) => (
+                    <button
+                        key={key}
+                        onClick={() => setPaymentStatus(key)}
+                        className={`px-4 py-2 text-sm rounded-lg ${
+                            paymentStatus === key ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700'
+                        } !rounded-button whitespace-nowrap`}
+                    >
+                        {label}
+                    </button>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default FiltersBar;

--- a/frontend/src/features/payment/components/Pagination.tsx
+++ b/frontend/src/features/payment/components/Pagination.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+interface PaginationProps {
+    currentPage: number;
+    totalItems: number;
+    itemsPerPage: number;
+    onPrev: () => void;
+    onNext: () => void;
+}
+
+const Pagination: React.FC<PaginationProps> = ({
+                                                   currentPage,
+                                                   totalItems,
+                                                   itemsPerPage,
+                                                   onPrev,
+                                                   onNext,
+                                               }) => {
+    const totalPages = Math.max(1, Math.ceil(totalItems / itemsPerPage));
+
+    return (
+        <div className="flex items-center justify-end mt-6">
+            <div className="flex items-center space-x-2">
+                <button
+                    onClick={onPrev}
+                    className="px-3 py-2 border rounded-lg text-sm text-gray-600 hover:bg-gray-50 !rounded-button whitespace-nowrap"
+                    disabled={currentPage === 1}
+                >
+                    이전
+                </button>
+                <span className="px-4 py-2 text-sm text-gray-700">
+          {currentPage} / {totalPages}
+        </span>
+                <button
+                    onClick={onNext}
+                    className="px-3 py-2 border rounded-lg text-sm text-gray-600 hover:bg-gray-50 !rounded-button whitespace-nowrap"
+                    disabled={currentPage >= totalPages}
+                >
+                    다음
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default Pagination;

--- a/frontend/src/features/payment/components/PaymentsTable.tsx
+++ b/frontend/src/features/payment/components/PaymentsTable.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import type { Payment } from '../types/payment';
+
+interface PaymentsTableProps {
+    payments: Payment[];
+    onShowDetail: (payment: Payment) => void;
+}
+
+const PaymentsTable: React.FC<PaymentsTableProps> = ({ payments, onShowDetail }) => {
+    const statusLabel = (s: Payment['status']) => (s === 'completed' ? '결제완료' : '결제취소');
+    const statusClass = (s: Payment['status']) =>
+        s === 'completed' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800';
+
+    return (
+        <div className="overflow-x-auto">
+            <table className="w-full">
+                <thead>
+                <tr className="bg-gray-50">
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">결제일시</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">결제금액</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">포인트</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">결제수단</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">결제상태</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">상세보기</th>
+                </tr>
+                </thead>
+
+                <tbody className="bg-white divide-y divide-gray-200">
+                {payments.map((p) => (
+                    <tr key={p.id} className="hover:bg-gray-50">
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{p.date}</td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                            {p.amount.toLocaleString('ko-KR')}원
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-blue-600 font-medium">
+                            +{p.convertedPoint.toLocaleString('ko-KR')}P
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{p.method}</td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                <span className={`px-3 py-1 inline-flex text-xs leading-5 font-semibold rounded-full ${statusClass(p.status)}`}>
+                  {statusLabel(p.status)}
+                </span>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm">
+                            <button
+                                onClick={() => onShowDetail(p)}
+                                className="text-blue-600 hover:text-blue-900 !rounded-button whitespace-nowrap"
+                            >
+                                상세보기
+                            </button>
+                        </td>
+                    </tr>
+                ))}
+
+                {payments.length === 0 && (
+                    <tr>
+                        <td colSpan={6} className="px-6 py-10 text-center text-sm text-gray-500">
+                            조회 결과가 없습니다.
+                        </td>
+                    </tr>
+                )}
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+export default PaymentsTable;

--- a/frontend/src/features/payment/components/ServerPagination.tsx
+++ b/frontend/src/features/payment/components/ServerPagination.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+interface Props {
+    page0: number;       // 0-based
+    totalPages: number;
+    onPrev: () => void;
+    onNext: () => void;
+}
+
+const ServerPagination: React.FC<Props> = ({ page0, totalPages, onPrev, onNext }) => {
+    const currentPage = page0 + 1; // 1-based 표기
+    return (
+        <div className="flex items-center justify-end mt-6">
+            <div className="flex items-center space-x-2">
+                <button
+                    onClick={onPrev}
+                    className="px-3 py-2 border rounded-lg text-sm text-gray-600 hover:bg-gray-50 !rounded-button whitespace-nowrap"
+                    disabled={page0 <= 0}
+                >
+                    이전
+                </button>
+                <span className="px-4 py-2 text-sm text-gray-700">
+          {currentPage} / {Math.max(1, totalPages)}
+        </span>
+                <button
+                    onClick={onNext}
+                    className="px-3 py-2 border rounded-lg text-sm text-gray-600 hover:bg-gray-50 !rounded-button whitespace-nowrap"
+                    disabled={currentPage >= totalPages}
+                >
+                    다음
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default ServerPagination;

--- a/frontend/src/features/payment/constants/payments.ts
+++ b/frontend/src/features/payment/constants/payments.ts
@@ -1,0 +1,53 @@
+// 서버 DTO
+export type ServerPaymentStatus = 'SUCCESS' | 'CANCELLED' | 'FAILED' | 'PENDING';
+
+export interface ServerPayment {
+    paymentId: number;
+    userId: number;
+    orderId: string;
+    transactionId: string;
+    amount: number;
+    paymentMethod: string;  // 'CARD' | ...
+    provider: string;       // 'PORTONE' | ...
+    paymentStatus: ServerPaymentStatus;
+    charged: boolean;
+    convertedPoint: number;
+    requestedAt: string;    // '2025-08-30T20:16:24.843663'
+    confirmedAt?: string | null;
+}
+
+export interface PaymentsPageDto {
+    page: number;           // 0-based
+    content: ServerPayment[];
+    size: number;
+    totalElements: number;
+    totalPages: number;
+    first: boolean;
+    last: boolean;
+}
+
+export type UiStatus = 'completed' | 'cancelled';
+
+export interface Payment {
+    id: number;
+    userId: number;
+    orderId: string;
+    transactionId: string;
+    amount: number;          // 금액(원)
+    convertedPoint: number;  // 전환 포인트
+    method: string;          // '신용카드' 등 한글 표기
+    status: UiStatus;        // 배지 색상용: 완료/취소
+    date: string;            // 테이블 표시 날짜 'YYYY-MM-DD'
+    requestedAt: string;
+    confirmedAt?: string;
+}
+
+export interface FetchPaymentsParams {
+    userId: number;
+    page?: number;           // 0-based
+    size?: number;
+    status?: ServerPaymentStatus | 'ALL';
+    from?: string;           // 'YYYY-MM-DD'
+    to?: string;             // 'YYYY-MM-DD'
+    sort?: string;           // 'requestedAt,desc' 등
+}

--- a/frontend/src/features/payment/hooks/usePagination.ts
+++ b/frontend/src/features/payment/hooks/usePagination.ts
@@ -1,0 +1,26 @@
+import { useEffect, useMemo, useState } from 'react';
+
+export function usePagination<T>(
+    items: T[],
+    options?: { itemsPerPage?: number; initialPage?: number },
+) {
+    const itemsPerPage = options?.itemsPerPage ?? 10;
+    const [currentPage, setCurrentPage] = useState<number>(options?.initialPage ?? 1);
+
+    const totalPages = Math.max(1, Math.ceil(items.length / itemsPerPage));
+
+    const paged = useMemo(() => {
+        const start = (currentPage - 1) * itemsPerPage;
+        return items.slice(start, start + itemsPerPage);
+    }, [items, currentPage, itemsPerPage]);
+
+    // 리스트가 바뀌면 1페이지로 리셋
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [items]);
+
+    const goPrev = () => setCurrentPage((p) => Math.max(1, p - 1));
+    const goNext = () => setCurrentPage((p) => Math.min(totalPages, p + 1));
+
+    return { currentPage, setCurrentPage, totalPages, itemsPerPage, paged, goPrev, goNext };
+}

--- a/frontend/src/features/payment/hooks/usePaymentDetailModal.ts
+++ b/frontend/src/features/payment/hooks/usePaymentDetailModal.ts
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+import type { Payment } from '../types/payment';
+
+export function usePaymentDetailModal() {
+    const [visible, setVisible] = useState<boolean>(false);
+    const [selected, setSelected] = useState<Payment | null>(null);
+
+    const open = (p: Payment) => {
+        setSelected(p);
+        setVisible(true);
+    };
+    const close = () => setVisible(false);
+
+    return { visible, selected, open, close };
+}

--- a/frontend/src/features/payment/hooks/usePaymentFilters.ts
+++ b/frontend/src/features/payment/hooks/usePaymentFilters.ts
@@ -1,0 +1,61 @@
+import { useMemo, useState } from 'react';
+import type { DateFilter, Payment, PaymentTableFilter } from '../types/payment';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function parseYMD(dateStr: string): Date {
+    const [y, m, d] = dateStr.split('-').map(Number);
+    return new Date(y, (m ?? 1) - 1, d ?? 1);
+}
+
+function rangeFor(filter: DateFilter) {
+    const end = new Date();
+    end.setHours(23, 59, 59, 999);
+    const start = new Date(end);
+    switch (filter) {
+        case 'today':
+            start.setHours(0, 0, 0, 0);
+            break;
+        case '1week':
+            start.setTime(end.getTime() - 7 * DAY_MS);
+            break;
+        case '1month':
+            start.setTime(end.getTime() - 30 * DAY_MS);
+            break;
+        case '3months':
+            start.setTime(end.getTime() - 90 * DAY_MS);
+            break;
+    }
+    return { start, end };
+}
+
+export function usePaymentFilters(payments: Payment[]) {
+    const [dateFilter, setDateFilter] = useState<DateFilter>('1month');
+    const [searchTerm, setSearchTerm] = useState<string>('');
+    const [paymentStatus, setPaymentStatus] = useState<PaymentTableFilter>('all');
+
+    const filtered = useMemo(() => {
+        const { start, end } = rangeFor(dateFilter);
+        const q = searchTerm.trim().toLowerCase();
+
+        return payments
+            .filter((p) => {
+                const d = parseYMD(p.date);
+                if (d < start || d > end) return false;
+                if (paymentStatus !== 'all' && p.status !== paymentStatus) return false;
+                if (q && !p.method.toLowerCase().includes(q)) return false;
+                return true;
+            })
+            .sort((a, b) => (a.date < b.date ? 1 : -1));
+    }, [payments, dateFilter, searchTerm, paymentStatus]);
+
+    return {
+        dateFilter,
+        setDateFilter,
+        searchTerm,
+        setSearchTerm,
+        paymentStatus,
+        setPaymentStatus,
+        filtered,
+    };
+}

--- a/frontend/src/features/payment/hooks/usePayments.ts
+++ b/frontend/src/features/payment/hooks/usePayments.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import type { Payment } from '../types/payment.ts'; // 파일명이 Payment.ts면 대소문자 맞추기!
+import { fetchPayments } from '../services/paymentService';
+
+export function usePayments(userId: number) { // ← userId를 훅 인자로 받자
+    const [payments, setPayments] = useState<Payment[]>([]);
+    const [loading, setLoading] = useState<boolean>(false);
+    const [error, setError] = useState<Error | null>(null);
+
+    const reload = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await fetchPayments({
+                userId,
+                page: 0,               // 서버 페이징(0-based)
+                size: 20,
+                status: 'ALL',
+                sort: 'requestedAt,desc',
+            });
+            setPayments(res.items);
+        } catch (e) {
+            setError(e instanceof Error ? e : new Error('Unknown error'));
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        void reload();
+    }, [userId]); // userId 변동시 리로드
+
+    return { payments, setPayments, loading, error, reload };
+}

--- a/frontend/src/features/payment/hooks/useServerPayments.ts
+++ b/frontend/src/features/payment/hooks/useServerPayments.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import type { FetchPaymentsParams, Payment, ServerPaymentStatus } from '../types/payment';
+import { fetchPayments } from '../services/paymentService';
+
+export function useServerPayments(initial: FetchPaymentsParams) {
+    const [params, setParams] = useState<FetchPaymentsParams>(initial);
+    const [items, setItems] = useState<Payment[]>([]);
+    const [page, setPage] = useState<number>(initial.page ?? 0); // 0-based
+    const [size, setSize] = useState<number>(initial.size ?? 10);
+    const [totalPages, setTotalPages] = useState<number>(1);
+    const [totalElements, setTotalElements] = useState<number>(0);
+    const [loading, setLoading] = useState<boolean>(false);
+    const [error, setError] = useState<Error | null>(null);
+
+    const reload = async (override?: Partial<FetchPaymentsParams>) => {
+        setLoading(true);
+        setError(null);
+        try {
+            const merged = { ...params, ...override, page, size };
+            const res = await fetchPayments(merged);
+            setItems(res.items);
+            setTotalPages(res.totalPages);
+            setTotalElements(res.totalElements);
+        } catch (e) {
+            setError(e instanceof Error ? e : new Error('Unknown error'));
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        void reload();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [page, size, params.userId, params.status, params.from, params.to, params.sort]);
+
+    return {
+        items, loading, error,
+        page, size, totalPages, totalElements,
+        setPage, setSize, setParams, reload,
+    };
+}
+
+// UI 필터값 → 서버 상태값 변환
+export function toServerStatus(ui: 'all' | 'completed' | 'cancelled'): ServerPaymentStatus | 'ALL' {
+    if (ui === 'all') return 'ALL';
+    return ui === 'completed' ? 'SUCCESS' : 'CANCELLED';
+}

--- a/frontend/src/features/payment/pages/PaymentRecordsPage.tsx
+++ b/frontend/src/features/payment/pages/PaymentRecordsPage.tsx
@@ -1,0 +1,142 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import FiltersBar from '../components/FiltersBar';
+import PaymentsTable from '../components/PaymentsTable';
+import DetailModal from '../components/DetailModal';
+import ServerPagination from '../components/ServerPagination';
+import type { DateFilter, Payment, PaymentTableFilter } from '../types/payment';
+import { useServerPayments, toServerStatus } from '../hooks/useServerPayments';
+
+// 로컬 타임존 기준 YYYY-MM-DD 범위 계산
+function formatYMDLocal(d: Date) {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+}
+
+function rangeFor(filter: DateFilter) {
+    const end = new Date();
+    end.setHours(23, 59, 59, 999);
+    const start = new Date(end);
+    const DAY = 24 * 60 * 60 * 1000;
+
+    switch (filter) {
+        case 'today':  start.setHours(0, 0, 0, 0); break;
+        case '1week':  start.setTime(end.getTime() - 7 * DAY); break;
+        case '1month': start.setTime(end.getTime() - 30 * DAY); break;
+        case '3months':start.setTime(end.getTime() - 90 * DAY); break;
+    }
+    return { from: formatYMDLocal(start), to: formatYMDLocal(end) };
+}
+
+const PaymentRecordsPage: React.FC = () => {
+    // 페이지 상태
+    const [dateFilter, setDateFilter] = useState<DateFilter>('1month');
+    const [searchTerm, setSearchTerm] = useState<string>('');
+    const [paymentStatus, setPaymentStatus] = useState<PaymentTableFilter>('all');
+
+    // TODO: 실제 로그인 유저의 ID로 교체
+    const userId = 1; //하드코딩 -> 후에 추가
+
+    const { from, to } = rangeFor(dateFilter);
+
+    const {
+        items, loading, error, page, totalPages, setPage, setParams,
+    } = useServerPayments({
+        userId,
+        page: 0,
+        size: 10,
+        status: 'ALL',
+        from,
+        to,
+        sort: 'requestedAt,desc',
+    });
+
+    // 필터 변경 시 서버 파라미터 갱신 + 첫 페이지로 이동
+    useEffect(() => {
+        setParams((p) => ({
+            ...p,
+            userId,
+            status: toServerStatus(paymentStatus),
+            from,
+            to,
+            sort: 'requestedAt,desc',
+        }));
+        setPage(0);
+    }, [userId, paymentStatus, from, to, setParams, setPage]);
+
+    // 검색어는 클라이언트에서 결제수단(method)에만 적용
+    const visible = useMemo(
+        () =>
+            items.filter((p) =>
+                searchTerm.trim()
+                    ? p.method.toLowerCase().includes(searchTerm.trim().toLowerCase())
+                    : true
+            ),
+        [items, searchTerm],
+    );
+
+    // 상세 모달
+    const [showDetailModal, setShowDetailModal] = useState(false);
+    const [selectedPayment, setSelectedPayment] = useState<Payment | null>(null);
+    const openDetail = (p: Payment) => { setSelectedPayment(p); setShowDetailModal(true); };
+
+    return (
+        <div className="min-h-screen bg-gray-50">
+            {/* 헤더 */}
+            <header className="bg-white shadow-sm border-b">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                    <div className="flex justify-between items-center h-16">
+                        <div className="flex items-center">
+                            <a href="#" className="text-gray-600 hover:text-gray-900">
+                                <i className="fas fa-arrow-left mr-2" />
+                                뒤로가기
+                            </a>
+                            <h1 className="text-2xl font-bold text-gray-900 ml-6">결제내역 조회</h1>
+                        </div>
+                    </div>
+                </div>
+            </header>
+
+            {/* 본문 */}
+            <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                <div className="bg-white rounded-lg shadow-sm p-6">
+                    <FiltersBar
+                        dateFilter={dateFilter}
+                        setDateFilter={setDateFilter}
+                        searchTerm={searchTerm}
+                        setSearchTerm={setSearchTerm}
+                        paymentStatus={paymentStatus}
+                        setPaymentStatus={setPaymentStatus}
+                    />
+
+                    {loading && <div className="py-10 text-center text-sm text-gray-500">불러오는 중…</div>}
+                    {error && (
+                        <div className="py-10 text-center text-sm text-red-600">
+                            데이터를 불러오지 못했습니다: {error.message}
+                        </div>
+                    )}
+
+                    {!loading && !error && (
+                        <>
+                            <PaymentsTable payments={visible} onShowDetail={openDetail} />
+
+                            <ServerPagination
+                                page0={page}
+                                totalPages={totalPages}
+                                onPrev={() => setPage(Math.max(0, page - 1))}
+                                onNext={() => setPage(page + 1)}
+                            />
+                        </>
+                    )}
+                </div>
+            </main>
+
+            {showDetailModal && selectedPayment && (
+                <DetailModal payment={selectedPayment} onClose={() => setShowDetailModal(false)} />
+            )}
+        </div>
+    );
+};
+
+export default PaymentRecordsPage;

--- a/frontend/src/features/payment/services/paymentService.ts
+++ b/frontend/src/features/payment/services/paymentService.ts
@@ -1,0 +1,91 @@
+import type {
+    FetchPaymentsParams,
+    PaymentsPageDto,
+    ServerPayment,
+    ServerPaymentStatus,
+    Payment,
+} from '../types/payment';
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
+
+function formatYMDLocal(d: Date) {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+}
+
+function toYmd(isoOrYmd?: string | null) {
+    if (!isoOrYmd) return '';
+    const d = new Date(isoOrYmd);
+    if (!Number.isNaN(d.getTime())) return formatYMDLocal(d);
+    return isoOrYmd.slice(0, 10);
+}
+
+function mapMethodToKo(code: string) {
+    switch (code) {
+        case 'CARD': return '신용카드';
+        case 'KAKAO_PAY': return '카카오페이';
+        case 'TRANSFER': return '계좌이체';
+        default: return code;
+    }
+}
+
+function mapStatusToUi(s: ServerPaymentStatus): 'completed' | 'cancelled' {
+    return s === 'SUCCESS' ? 'completed' : 'cancelled';
+}
+
+function mapServerPayment(p: ServerPayment): Payment {
+    const baseDate = p.confirmedAt || p.requestedAt;
+    return {
+        id: p.paymentId,
+        userId: p.userId,
+        orderId: p.orderId,
+        transactionId: p.transactionId,
+        amount: p.amount,
+        convertedPoint: p.convertedPoint,
+        method: mapMethodToKo(p.paymentMethod),
+        status: mapStatusToUi(p.paymentStatus),
+        date: toYmd(baseDate),
+        requestedAt: p.requestedAt,
+        confirmedAt: p.confirmedAt ?? null,
+    };
+}
+
+export async function fetchPayments(params: FetchPaymentsParams) {
+    const search = new URLSearchParams();
+
+    search.set('userId', String(params.userId));
+
+    // 선택
+    if (params.page != null) search.set('page', String(params.page)); // 0-based
+    if (params.size != null) search.set('size', String(params.size));
+    if (params.status && params.status !== 'ALL') search.set('status', params.status);
+    if (params.from) search.set('from', params.from);
+    if (params.to) search.set('to', params.to);
+    if (params.sort) search.set('sort', params.sort);
+
+    const res = await fetch(`${BASE_URL}/api/payments/records?${search.toString()}`, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        credentials: 'include', // 후에 Authorization 헤더 추가
+    });
+
+    if (!res.ok) {
+        const t = await res.text().catch(() => '');
+        throw new Error(`Payments fetch failed: ${res.status} ${t}`);
+    }
+
+    const json = (await res.json()) as PaymentsPageDto;
+    const items = (json.content ?? []).map(mapServerPayment);
+
+    return {
+        items,
+        page: json.page,
+        size: json.size,
+        totalElements: json.totalElements,
+        totalPages: json.totalPages,
+        first: json.first,
+        last: json.last,
+    };
+}

--- a/frontend/src/features/payment/types/payment.ts
+++ b/frontend/src/features/payment/types/payment.ts
@@ -1,0 +1,61 @@
+// 서버 상태값
+export type PaymentStatus = 'SUCCESS' | 'CANCELLED' | 'FAILED' | 'PENDING';
+export type ServerPaymentStatus = PaymentStatus;
+
+// 서버 호출 파라미터
+export interface FetchPaymentsParams {
+    userId: number;  // 필수
+    page?: number;   // 0-based
+    size?: number;
+    status?: PaymentStatus | 'ALL';
+    from?: string;   // 'YYYY-MM-DD'
+    to?: string;     // 'YYYY-MM-DD'
+    sort?: string;   // 'requestedAt,desc'
+}
+
+// 서버 응답 아이템
+export interface ServerPayment {
+    paymentId: number;
+    userId: number;
+    orderId: string;
+    transactionId: string;
+    amount: number;
+    paymentMethod: string;
+    provider: string;
+    paymentStatus: PaymentStatus;
+    charged: boolean;
+    convertedPoint: number;
+    requestedAt: string;
+    confirmedAt?: string | null;
+}
+
+// 페이지 DTO
+export interface PaymentsPageDto {
+    page: number;
+    content: ServerPayment[];
+    size: number;
+    totalElements: number;
+    totalPages: number;
+    first: boolean;
+    last: boolean;
+}
+
+// UI 모델
+export type UiStatus = 'completed' | 'cancelled';
+export interface Payment {
+    id: number;
+    userId: number;
+    orderId: string;
+    transactionId: string;
+    amount: number;
+    convertedPoint: number;
+    method: string;
+    status: UiStatus;
+    date: string;            // YYYY-MM-DD
+    requestedAt: string;     // ISO
+    confirmedAt?: string | null;
+}
+
+// 필터 타입
+export type DateFilter = 'today' | '1week' | '1month' | '3months';
+export type PaymentTableFilter = 'all' | 'completed' | 'cancelled';

--- a/frontend/src/features/profile/components/mockData.ts
+++ b/frontend/src/features/profile/components/mockData.ts
@@ -4,7 +4,7 @@ import type { ProfileWishProps } from "../types/ProfileWishProps";
 
 export const menu = [
     { icon: "fas fa-shopping-cart", text: "주문/배송 조회", href: "/order" },
-    { icon: "fas fa-credit-card", text: "결제 내역 조회", href: "/payment/records" },
+    { icon: 'fas fa-receipt', text: '결제내역 조회', href: '/points/records' },
     { icon: "fas fa-heart", text: "찜한 상품", href: "/wish" },
     { icon: "fas fa-cog", text: "설정", href: "/setting" },
 ];

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -25,6 +25,9 @@ import AppLayout from "./components/AppLayout.tsx";
 import ChargePointsPage from './features/payment/pages/ChargePointsPage.tsx';
 import ChargeResultPage from './features/payment/pages/ChargeResultPage.tsx';
 
+import PaymentRecordsPage from './features/payment/pages/PaymentRecordsPage.tsx';
+
+
 const router = createBrowserRouter(
     createRoutesFromElements(
         <Route element={<AppLayout />}>
@@ -43,6 +46,7 @@ const router = createBrowserRouter(
             <Route path="/order/:orderId" element={<OrderDetailPage />} />
             <Route path="/wish" element={<WishPage />} />
             <Route path="/points/charge" element={<ChargePointsPage />} />
+            <Route path="/points/records" element={<PaymentRecordsPage />} />
             <Route path="/result" element={<ChargeResultPage />} />
             <Route path="/cart" element={<CartPage />} />
             <Route path="/policy" element={<PolicyPage />} />


### PR DESCRIPTION
- 서버 연동: useServerPayments 훅/ paymentService.fetchPayments 적용
- 라우팅: /points/records 경로 추가 및 프로필 퀵메뉴 연동
- 백엔드: PaymentsRepository.findRecordsByUserId JPQL 생성자 프로젝션 및 패키지 경로 정정

close #110 