### PR TITLE
feat: 공통 fetch 래퍼, 인증 시스템 구현 및 사용 가이드 추가

### DIFF
--- a/frontend/docs/AUTH_GUIDE.md
+++ b/frontend/docs/AUTH_GUIDE.md
@@ -1,0 +1,91 @@
+# 인증 사용 가이드
+
+이 문서는 화면/서비스 코드에서 인증 상태와 사용자 정보를 간단히 쓰는 방법만 정리합니다.
+
+- 토큰은 HttpOnly 쿠키로 관리됩니다. Authorization 헤더는 필요 없습니다.
+- 모든 API 요청은 credentials: 'include'가 자동으로 포함되어야 합니다(apiFetch 권장).
+
+## 1) 현재 로그인 사용자 접근: useAuth
+- 경로: `src/features/user/hooks/useAuth.ts`
+- 제공: `{ user, isAuthenticated, refreshMe, logout }`
+
+사용 예시
+```tsx
+import { useAuth } from '@/features/user/hooks/useAuth';
+
+export default function MySection() {
+  const { user, isAuthenticated, refreshMe, logout } = useAuth();
+
+  if (!isAuthenticated) return <a href="/login">로그인</a>;
+
+  return (
+    <div>
+      <p>안녕하세요, {user?.nickname ?? user?.email}</p>
+      <button onClick={() => void refreshMe()}>내 정보 새로고침</button>
+      <button onClick={() => void logout()}>로그아웃</button>
+    </div>
+  );
+}
+```
+팁
+- 첫 진입에 세션 캐시가 없으면 `refreshMe()`가 `/api/users/me`로 동기화합니다.
+
+## 2) 인증 필요한 페이지 보호: ProtectedRoute
+- 경로: `src/features/user/components/ProtectedRoute.tsx`
+- 미로그인 시 `/login`으로 이동. 쿠키만 있는 케이스를 위해 최초 진입에 자동 동기화 수행.
+
+라우터 적용 예시 (일부 이미 적용됨)
+```tsx
+<Route path="/profile" element={<ProtectedRoute><ProfilePage /></ProtectedRoute>} />
+<Route path="/wish" element={<ProtectedRoute><WishPage /></ProtectedRoute>} />
+```
+
+## 3) API 호출: apiFetch 공통 래퍼
+- 경로: `src/utils/apiFetch.ts`
+- 기본으로 `credentials: 'include'` 포함, JSON 전송은 `json` 옵션 사용
+
+예시
+```ts
+import { apiFetch } from '@/utils/apiFetch';
+
+// GET
+const me = await apiFetch('/api/users/me');
+
+// POST(JSON 자동 직렬화)
+const res = await apiFetch('/api/users/login', {
+  method: 'POST',
+  json: { email, password },
+});
+```
+
+## 4) 로그인/닉네임 완료 등 사용자 정보 갱신 알림
+- 경로: `src/features/user/services/AuthService.ts`
+- 함수: `cacheUserAndEmit(user)`
+- 효과: 세션(`sessionStorage['auth.user']`) 저장 + 전역 이벤트(`auth-changed`) 브로드캐스트
+
+사용 예시
+```ts
+import { cacheUserAndEmit } from '@/features/user/services/AuthService';
+
+// 로그인 성공 시 응답 사용자 객체를 전달
+cacheUserAndEmit(loginResponse.data);
+```
+
+## 5) 실제 연동 예: 포인트 조회
+- API: `GET /api/users/{userId}/points` (백엔드에서 DTO로 응답)
+- 프런트: `src/features/profile/api/point.ts`
+
+예시
+```ts
+import { apiFetch } from '@/utils/apiFetch';
+
+export async function fetchUserPoint(userId: number) {
+  return apiFetch(`/api/users/${userId}/points`);
+}
+```
+
+## 문제 해결 체크리스트
+- 401/403 발생: 쿠키 전송 여부 확인(apiFetch 사용 또는 `credentials: 'include'`).
+- 첫 렌더에서 비로그인처럼 보임: ProtectedRoute 또는 `refreshMe()`로 동기화.
+- 사용자 표시 정보가 갱신되지 않음: 갱신 시점에 `cacheUserAndEmit(updatedUser)` 호출 필요.
+

--- a/frontend/src/features/profile/api/point.ts
+++ b/frontend/src/features/profile/api/point.ts
@@ -1,32 +1,12 @@
-import type { PointSummaryResponse, ApiErrorResponse } from "../types/ProfilePointProps";
+import { apiFetch } from "../../../utils/apiFetch";
+import type { PointSummaryResponse } from "../types/ProfilePointProps";
 
-const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8080/api";
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "/api";
 
 export async function fetchUserPoint(userId: number): Promise<PointSummaryResponse> {
-
-    const token = localStorage.getItem("accessToken"); // 또는 Context/Recoil에서 관리
-
-    const res = await fetch(`${BASE_URL}/users/${userId}/points`, {
+    // ApiResponse 스키마가 아닌 순수 DTO를 반환하므로 제네릭은 unknown으로 두고 수동 캐스팅
+    const data = await apiFetch<unknown>(`${BASE_URL}/users/${userId}/points`, {
         method: "GET",
-        headers: {
-            "Accept": "application/json",
-            "Authorization": `Bearer ${token}`,   //  JWT 붙이기
-        },
     });
-
-    if (!res.ok) {
-        let msg = `HTTP ${res.status}`;
-        try {
-            const data: unknown = await res.json();
-            const err = data as Partial<ApiErrorResponse>;
-            if (err.errorCode && err.message) {
-                msg = `${err.errorCode}: ${err.message}`;
-            }
-        } catch (e) {
-            console.error("Error parsing error response:", e);
-        }
-        throw new Error(msg);
-    }
-
-    return res.json() as Promise<PointSummaryResponse>;
+    return data as PointSummaryResponse;
 }

--- a/frontend/src/features/profile/components/ProfilePoint.tsx
+++ b/frontend/src/features/profile/components/ProfilePoint.tsx
@@ -2,36 +2,17 @@ import { Fragment, useEffect, useState } from "react";
 import { useModal } from "../../../contexts/modal/modal";
 import { fetchUserPoint } from "../api/point";
 import type { PointSummaryResponse } from "../types/ProfilePointProps";
-
-type AuthUser = {
-    userId?: number;
-    email?: string;
-    nickname?: string;
-    [key: string]: unknown;
-};
+import { useAuth } from "../../user/hooks/useAuth";
 
 const ProfilePoint = () => {
     const { openModal, closeModal } = useModal();
+    const { user } = useAuth();
     const [point, setPoint] = useState<number | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
-    // 임시 하드코딩 : 실제 로그인된 유저 ID를 auth로 가져와야 함 (jwt 설정)
-    //const userId = 1;+
-
-    // 세션에 저장된 로그인 사용자 정보에서 userId 읽기
-    const getCurrentUser = (): AuthUser | null => {
-        try {
-            const raw = sessionStorage.getItem("auth.user");
-            if (!raw) return null;
-            return JSON.parse(raw) as AuthUser;
-        } catch {
-            return null;
-        }
-    };
-
-    const user = getCurrentUser();
-    const userId = user?.userId; // null이면 로그인 안 된 상태
+    // userId를 useAuth에서 가져옴
+    const userId = user?.userId;
 
     useEffect(() => {
         if (!userId) {
@@ -43,9 +24,6 @@ const ProfilePoint = () => {
         let alive = true;
         setLoading(true);
 
-        const token  = localStorage.getItem("accessToken")
-
-        console.log(`test toekn: ${token}`)
 
         fetchUserPoint(userId)
             .then((res: PointSummaryResponse) => {
@@ -147,112 +125,5 @@ const PointConvertFormat = ({ onClose }: { onClose: () => void }) => {
         </Fragment>
     );
 };
-
-
-
-/*
-    useEffect(() => {
-        let alive = true;
-        setLoading(true);
-        fetchUserPoint(userId)
-            .then((res: PointSummaryResponse) => {
-                if (alive) {
-                    setPoint(res.currentPoint);
-                    setError(null);
-                }
-            })
-            .catch((err: Error) => {
-                if (alive) setError(err.message);
-            })
-            .finally(() => {
-                if (alive) setLoading(false);
-            });
-        return () => { alive = false; };
-    }, [userId]);
-
-    const handleOpenModal = () => {
-        openModal(<PointConvertFormat onClose={closeModal} />);
-    };
-
-    return (
-        <div className="bg-white rounded-lg shadow-sm p-6 mb-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">
-                SloePay
-            </h3>
-            <div className="space-y-4">
-                <div className="flex justify-between items-center p-3 bg-blue-50 rounded-lg">
-                    <div>
-                        <div className="font-medium text-gray-900">
-                             보유 포인트
-                        </div>
-                        {loading ? (
-                            <div className="text-gray-400">불러오는 중...</div>
-                        ) : error ? (
-                            <div className="text-red-500">{error}</div>
-                        ) : (
-                            <div className="text-blue-600 font-semibold">
-                                {point?.toLocaleString()}P
-                            </div>
-                        )}
-                    </div>
-                    <i className="fas fa-coins text-blue-600 text-xl" />
-                </div>
-                <button
-                    onClick={handleOpenModal}
-                    className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 !rounded-button whitespace-nowrap">
-                    <i className="fas fa-exchange-alt mr-2" />
-                    SloePay 충전하기
-                </button>
-            </div>
-        </div>
-    );
-};
-
-const PointConvertFormat = ({ onClose }: { onClose: () => void }) => {
-    const handleConvert = () => {
-        alert("포인트 전환이 완료되었습니다.");
-        onClose();
-    };
-    return (
-        <Fragment>
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">
-                현금을 포인트로 전환
-            </h3>
-            <div className="mb-4">
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                    전환할 금액
-                </label>
-                <div className="relative">
-                    <input
-                        type="number"
-                        placeholder="금액을 입력하세요"
-                        min="1000"
-                        step="1000"
-                        className="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    />
-                    <span className="absolute right-10 top-2 text-gray-500">
-                        원
-                    </span>
-                </div>
-                <p className="text-sm text-gray-500 mt-1">
-                    최소 1,000원부터 전환 가능
-                </p>
-            </div>
-            <div className="flex justify-end space-x-3">
-                <button
-                    onClick={onClose}
-                    className="px-4 py-2 text-gray-600 hover:text-gray-900 !rounded-button whitespace-nowrap">
-                    취소
-                </button>
-                <button
-                    onClick={handleConvert}
-                    className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 !rounded-button whitespace-nowrap">
-                    전환하기
-                </button>
-            </div>
-        </Fragment>
-    );
-};
-*/
 
 export default ProfilePoint;

--- a/frontend/src/features/user/components/ProtectedRoute.tsx
+++ b/frontend/src/features/user/components/ProtectedRoute.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+interface Props {
+  children: React.ReactElement;
+}
+
+const ProtectedRoute: React.FC<Props> = ({ children }) => {
+  const { isAuthenticated, refreshMe } = useAuth();
+  const location = useLocation();
+  const [checking, setChecking] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      if (!isAuthenticated) {
+        await refreshMe();
+      }
+      if (alive) setChecking(false);
+    })();
+    return () => { alive = false; };
+  }, [isAuthenticated, refreshMe]);
+
+  if (checking) {
+    return <div className="min-h-[200px] flex items-center justify-center text-gray-500 text-sm">확인 중…</div>;
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+  return children;
+};
+
+export default ProtectedRoute;

--- a/frontend/src/features/user/hooks/useAuth.ts
+++ b/frontend/src/features/user/hooks/useAuth.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { AuthUser } from '../types/AuthTypes';
+import { logout as apiLogout } from '../services/AuthService';
+
+function readSessionUser(): AuthUser | null {
+  try {
+    const raw = sessionStorage.getItem('auth.user');
+    if (!raw) return null;
+    return JSON.parse(raw) as AuthUser;
+  } catch (e) {
+    console.debug('readSessionUser: failed to parse', e);
+    return null;
+  }
+}
+
+export function useAuth() {
+  const [user, setUser] = useState<AuthUser | null>(() => readSessionUser());
+
+  const isAuthenticated = useMemo(() => Boolean(user && (user.userId || user.email)), [user]);
+
+  // 세션 변경 이벤트 구독
+  useEffect(() => {
+    const handler = (evt: Event) => {
+      try {
+        const u = (evt as CustomEvent).detail?.user as AuthUser | null | undefined;
+        if (u) setUser(u);
+        else setUser(null);
+      } catch (e) {
+        console.debug('auth event parse error', e);
+      }
+    };
+    window.addEventListener('auth-changed', handler as EventListener);
+    return () => window.removeEventListener('auth-changed', handler as EventListener);
+  }, []);
+
+  const refreshMe = useCallback(async (): Promise<AuthUser | null> => {
+    try {
+      const res = await fetch('/api/users/me', { credentials: 'include' });
+      const payload = await res.json();
+      if (res.ok && payload?.success && payload?.data) {
+        try { sessionStorage.setItem('auth.user', JSON.stringify(payload.data)); } catch (e) { console.debug('failed to cache user', e); }
+        const evt = new CustomEvent('auth-changed', { detail: { user: payload.data } });
+        window.dispatchEvent(evt);
+        setUser(payload.data as AuthUser);
+        return payload.data as AuthUser;
+      }
+    } catch (e) {
+      console.debug('refreshMe failed', e);
+    }
+    return null;
+  }, []);
+
+  const logout = useCallback(async () => {
+    try { await apiLogout(); } catch (e) { console.debug('logout api failed', e); }
+    try { sessionStorage.removeItem('auth.user'); } catch (e) { console.debug('remove session failed', e); }
+    const evt = new CustomEvent('auth-changed', { detail: { user: null } });
+    window.dispatchEvent(evt);
+    setUser(null);
+  }, []);
+
+  return { user, isAuthenticated, refreshMe, logout } as const;
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -24,6 +24,7 @@ import AppLayout from "./components/AppLayout.tsx";
 
 import ChargePointsPage from './features/payment/pages/ChargePointsPage.tsx';
 import ChargeResultPage from './features/payment/pages/ChargeResultPage.tsx';
+import ProtectedRoute from './features/user/components/ProtectedRoute';
 
 import PaymentRecordsPage from './features/payment/pages/PaymentRecordsPage.tsx';
 
@@ -41,17 +42,17 @@ const router = createBrowserRouter(
             <Route path="/category/:categoryName" element={<CategoryPage />} />
             <Route path="/search" element={<SearchPage />} />
             <Route path="/ranking" element={<RankingPage />} />
-            <Route path="/profile" element={<ProfilePage />} />
-            <Route path="/order" element={<OrderPage />} />
-            <Route path="/order/:orderId" element={<OrderDetailPage />} />
-            <Route path="/wish" element={<WishPage />} />
-            <Route path="/points/charge" element={<ChargePointsPage />} />
-            <Route path="/points/records" element={<PaymentRecordsPage />} />
+            <Route path="/profile" element={<ProtectedRoute><ProfilePage /></ProtectedRoute>} />
+            <Route path="/order" element={<ProtectedRoute><OrderPage /></ProtectedRoute>} />
+            <Route path="/order/:orderId" element={<ProtectedRoute><OrderDetailPage /></ProtectedRoute>} />
+            <Route path="/wish" element={<ProtectedRoute><WishPage /></ProtectedRoute>} />
+            <Route path="/points/charge" element={<ProtectedRoute><ChargePointsPage /></ProtectedRoute>} />
+            <Route path="/points/records" element={<ProtectedRoute><PaymentRecordsPage /></ProtectedRoute>} />
             <Route path="/result" element={<ChargeResultPage />} />
             <Route path="/cart" element={<CartPage />} />
             <Route path="/policy" element={<PolicyPage />} />
-            <Route path="/notification" element={<NotificationPage />} />
-            <Route path="/setting" element={<SettingPage />} />
+            <Route path="/notification" element={<ProtectedRoute><NotificationPage /></ProtectedRoute>} />
+            <Route path="/setting" element={<ProtectedRoute><SettingPage /></ProtectedRoute>} />
         </Route>
     )
 )

--- a/frontend/src/utils/apiFetch.ts
+++ b/frontend/src/utils/apiFetch.ts
@@ -1,0 +1,30 @@
+// 공통 fetch 래퍼: 쿠키 전송 + JSON 파싱 일관화
+export type ApiFetchInit = RequestInit & { json?: unknown };
+
+export async function apiFetch<T = unknown>(input: string | URL | Request, init?: ApiFetchInit): Promise<T> {
+  const headers = new Headers(init?.headers ?? {});
+  if (init?.json !== undefined) {
+    headers.set('Content-Type', 'application/json');
+  }
+  if (!headers.has('Accept')) headers.set('Accept', 'application/json');
+
+  const res = await fetch(input, {
+    ...init,
+    headers,
+    credentials: 'include',
+    body: init?.json !== undefined ? JSON.stringify(init.json) : init?.body,
+  });
+
+  const text = await res.text();
+  const data: unknown = text ? JSON.parse(text) : undefined;
+
+  if (!res.ok) {
+    let msg = `HTTP ${res.status}`;
+    if (data && typeof data === 'object' && 'message' in data) {
+      const m = (data as { message?: unknown }).message;
+      if (typeof m === 'string' && m) msg = m;
+    }
+    throw new Error(msg);
+  }
+  return data as T;
+}


### PR DESCRIPTION
refactor: CookieUtil 도입 및 컨트롤러 적용 #102

**관련 이슈**

- closes #188 

주요 변경사항

-  useAuth 훅 구현

   - sessionStorage와 CustomEvent를 이용해 브라우저 세션과 탭 간의 인증 상태를 일관되게 관리합니다.

   - refreshMe 함수로 페이지 첫 진입 시 사용자의 최신 정보를 비동기적으로 가져옵니다.

- ProtectedRoute 컴포넌트 구현

   - 인증이 필요한 페이지를 감싸, 비인증 사용자의 접근을 막고 로그인 페이지로 안전하게 리디렉션합니다.

   - 인증 상태 확인 중 로딩 UI를 표시하여 UX를 개선했습니다.

- apiFetch 공통 래퍼 추가

   - 모든 API 요청에 credentials: 'include' 옵션을 기본으로 적용하여, 매번 인증 쿠키 설정을 반복할 필요가 없도록 개선했습니다.

- 인증 사용 가이드.md 문서 추가

   - 위 기능들의 사용법, API 호출 예시, 자주 묻는 질문(FAQ) 및 문제 해결 체크리스트를 포함하여 다른 개발자들이 빠르게 적응할 수 있도록 돕습니다.