### PR TITLE
feat: 표준화된 HTTP 상태 코드 사용을 위한 ErrorCode 수정

### DIFF
--- a/backend/demo/src/main/java/com/sesac/solbid/exception/ErrorCode.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/exception/ErrorCode.java
@@ -2,71 +2,70 @@ package com.sesac.solbid.exception;
 
 import org.springframework.http.HttpStatus;
 
-
 public enum ErrorCode {
-    INVALID_PARAMETER(400, "매개변수 값이 잘못되었습니다"),
-    DB_CONSTRAINT_VIOLATION(409, "DB 제약조건 위반"),
-    TRANSACTION_FAILED(500, "트랜잭션 실패"),
-    BAD_REQUEST_BODY(400, "요청 값이 잘못되었습니다"),
-    PARAMETER_TYPE_MISMATCH(400, "요청 파라미터 타입 오류"),
-    VALIDATION_ERROR(400, "유효성 검사 실패"),
-    FILE_UPLOAD_FAILED(400, "파일 업로드 실패"),
-    INTERNAL_SERVER_ERROR(500, "서버 내부 오류"),
+    // 공통
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "매개변수 값이 잘못되었습니다"),
+    DB_CONSTRAINT_VIOLATION(HttpStatus.CONFLICT, "DB 제약조건 위반"),
+    TRANSACTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "트랜잭션 실패"),
+    BAD_REQUEST_BODY(HttpStatus.BAD_REQUEST, "요청 값이 잘못되었습니다"),
+    PARAMETER_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "요청 파라미터 타입 오류"),
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "유효성 검사 실패"),
+    FILE_UPLOAD_FAILED(HttpStatus.BAD_REQUEST, "파일 업로드 실패"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류"),
 
     // 회원 가입 에러
-    DUPLICATE_EMAIL(400, "이미 사용 중인 이메일 주소입니다."),
-    DUPLICATE_NICKNAME(400, "이미 사용 중인 닉네임입니다."),
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 사용 중인 이메일 주소입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
 
     // 로그인 에러
-    LOGIN_FAILED(401, "이메일 또는 비밀번호가 올바르지 않습니다."),
-    INACTIVE_USER(401, "비활성화된 계정입니다."),
-    WITHDRAWN_USER(401, "회원 탈퇴 처리된 계정입니다."),
-    WITHDRAWAL_GRACE_PERIOD_EXPIRED(401, "탈퇴 유예 기간이 만료된 계정입니다."),
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
+    INACTIVE_USER(HttpStatus.UNAUTHORIZED, "비활성화된 계정입니다."),
+    WITHDRAWN_USER(HttpStatus.UNAUTHORIZED, "회원 탈퇴 처리된 계정입니다."),
+    WITHDRAWAL_GRACE_PERIOD_EXPIRED(HttpStatus.UNAUTHORIZED, "탈퇴 유예 기간이 만료된 계정입니다."),
 
     // OAuth2 소셜로그인 에러
-    INVALID_OAUTH2_PROVIDER(400, "지원하지 않는 OAuth2 제공자입니다."),
-    OAUTH2_STATE_MISMATCH(400, "OAuth2 state 파라미터가 일치하지 않습니다."),
-    OAUTH2_TOKEN_ERROR(400, "OAuth2 액세스 토큰 획득에 실패했습니다."),
-    OAUTH2_USER_INFO_ERROR(400, "OAuth2 사용자 정보 획득에 실패했습니다."),
-    SOCIAL_ACCOUNT_CONFLICT(409, "이미 다른 소셜 계정으로 연결된 이메일입니다."),
+    INVALID_OAUTH2_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 OAuth2 제공자입니다."),
+    OAUTH2_STATE_MISMATCH(HttpStatus.BAD_REQUEST, "OAuth2 state 파라미터가 일치하지 않습니다."),
+    OAUTH2_TOKEN_ERROR(HttpStatus.BAD_REQUEST, "OAuth2 액세스 토큰 획득에 실패했습니다."),
+    OAUTH2_USER_INFO_ERROR(HttpStatus.BAD_REQUEST, "OAuth2 사용자 정보 획득에 실패했습니다."),
+    SOCIAL_ACCOUNT_CONFLICT(HttpStatus.CONFLICT, "이미 다른 소셜 계정으로 연결된 이메일입니다."),
 
     // 비밀번호 재설정
-    PASSWORD_RESET_TOKEN_INVALID(400, "비밀번호 재설정 토큰이 유효하지 않습니다."),
-    PASSWORD_RESET_TOKEN_EXPIRED(400, "비밀번호 재설정 토큰이 만료되었습니다."),
-    PASSWORD_RESET_SAME_AS_OLD(400, "이전에 사용한 비밀번호와 동일합니다."),
-    USER_NOT_FOUND(404, "사용자를 찾을 수 없습니다."),
-    EMAIL_SEND_FAILED(500, "이메일 발송에 실패했습니다."),
-    OAUTH_TOKEN_FAILED(500, "Google OAuth2 Access Token 발급에 실패했습니다."),
-    PASSWORD_RESET_NOT_ALLOWED(400, "해당 계정은 비밀번호 재설정을 지원하지 않습니다."),
+    PASSWORD_RESET_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "비밀번호 재설정 토큰이 유효하지 않습니다."),
+    PASSWORD_RESET_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "비밀번호 재설정 토큰이 만료되었습니다."),
+    PASSWORD_RESET_SAME_AS_OLD(HttpStatus.BAD_REQUEST, "이전에 사용한 비밀번호와 동일합니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 발송에 실패했습니다."),
+    OAUTH_TOKEN_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Google OAuth2 Access Token 발급에 실패했습니다."),
+    PASSWORD_RESET_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "해당 계정은 비밀번호 재설정을 지원하지 않습니다."),
 
-    // 포인트 관련 에러 (HttpStatus 기반)
+    // 포인트 관련 에러
     POINT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자의 포인트 정보가 존재하지 않습니다."),
     INSUFFICIENT_POINT(HttpStatus.BAD_REQUEST, "포인트가 부족합니다."),
     POINT_TRANSACTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "포인트 트랜잭션 처리 중 오류가 발생했습니다."),
 
-    // 상품 관련 에러 (HttpStatus 기반)
+    // 상품 관련 에러
     INVALID_SIZE_RANGE(HttpStatus.BAD_REQUEST, "잘못된 사이즈 범위입니다."),
     THUMBNAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "중복된 썸네일입니다."),
     SORT_ORDER_DUPLICATED(HttpStatus.BAD_REQUEST, "정렬 순서가 중복되었습니다."),
     INVALID_IMAGE_KEY(HttpStatus.BAD_REQUEST, "잘못된 이미지 키입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다.");
 
-    private final int status;
+    private final HttpStatus status;
     private final String message;
 
-    ErrorCode(int status, String message) {
+    ErrorCode(HttpStatus status, String message) {
         this.status = status;
         this.message = message;
     }
 
-    // HttpStatus 생성자
-    ErrorCode(HttpStatus status, String message) {
-        this.status = status.value();
-        this.message = message;
+    public HttpStatus getStatus() {
+        return status;
     }
 
-    public int getStatus() {
-        return status;
+    // 정수 코드가 필요한 레거시 사용처 호환용
+    public int getStatusValue() {
+        return status.value();
     }
 
     public String getMessage() {


### PR DESCRIPTION
**관련 이슈**

- closes #223 

기존 `ErrorCode` 시스템에서 하드코딩된 정수(int) 타입으로 관리하던 HTTP 상태 코드를 **Spring Framework의 `HttpStatus` 열거형(Enum)으로 교체** 했습니다
