### PR TITLE
feat: S3 경매 상품 이미지 업로드 기능 구현

### DIFF
--- a/backend/demo/build.gradle
+++ b/backend/demo/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.4.0")
+    implementation "io.awspring.cloud:spring-cloud-aws-starter-s3"
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'software.amazon.awssdk:s3:2.20.110' // s3 의존성
     implementation 'org.mapstruct:mapstruct:1.5.5.Final' //MapStruct 설정

--- a/backend/demo/src/main/java/com/sesac/solbid/config/S3Config.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/config/S3Config.java
@@ -1,0 +1,69 @@
+package com.sesac.solbid.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config implements WebMvcConfigurer {
+
+    // properties에서 직접 주입 (env 아님 -> 후에 .env 파일로 수정 예정)
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String regionStr;
+
+    private StaticCredentialsProvider staticCreds() {
+        return StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(accessKey, secretKey)
+        );
+    }
+
+    /*
+    * 주입 예시
+    * @Value("${app.s3.bucket}")
+       private String bucket;*/
+
+    /*
+     * S3 설정*/
+    private Region region() {
+        return Region.of(regionStr);
+    }
+
+    @Bean(destroyMethod = "close")
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(region())
+                .credentialsProvider(staticCreds())
+                .build();
+    }
+
+    @Bean(destroyMethod = "close")
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(region())
+                .credentialsProvider(staticCreds())
+                .build();
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("GET","POST","PUT","DELETE","OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}

--- a/backend/demo/src/main/java/com/sesac/solbid/config/WebClientConfig.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/config/WebClientConfig.java
@@ -17,6 +17,8 @@ public class WebClientConfig implements WebMvcConfigurer {
     @Value("${portone.base-url}")
     private String portoneBaseUrl;
 
+    /*
+    * portOne 설정*/
     @Bean
     public WebClient portOneWebClient() {
         return WebClient.builder()

--- a/backend/demo/src/main/java/com/sesac/solbid/controller/ProductFinalizeController.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/controller/ProductFinalizeController.java
@@ -1,0 +1,32 @@
+package com.sesac.solbid.controller;
+
+import com.sesac.solbid.dto.upload.response.FinalizeImagesResponse;
+import com.sesac.solbid.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/products")
+public class ProductFinalizeController {
+    private final ProductService productService;
+
+    /**
+     * 상품 이미지 최종 확정
+     * POST /{id}/finalize-images
+     *
+     * @param id     상품 ID
+     * @param userId 요청자 사용자 ID (X-User-Id 헤더)
+     * @return 최종 확정 완료 여부와 상품 ID
+     */
+    @PostMapping("/{id}/finalize-images")
+    public ResponseEntity<FinalizeImagesResponse> finalizeImages(
+            @PathVariable Long id,
+            @RequestHeader("X-User-Id") Long userId) {
+        productService.finalizeImages(id, userId);
+        return ResponseEntity.ok(new FinalizeImagesResponse(id, true));
+    }
+}

--- a/backend/demo/src/main/java/com/sesac/solbid/controller/UploadController.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/controller/UploadController.java
@@ -1,0 +1,34 @@
+package com.sesac.solbid.controller;
+
+import com.sesac.solbid.dto.upload.request.PresignRequest;
+import com.sesac.solbid.dto.upload.response.PresignResponse;
+import com.sesac.solbid.service.UploadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/uploads")
+public class UploadController {
+
+    private final UploadService uploadService;
+
+    /*
+     * 파일 업로드용 Presigned URL 발급
+     * POST /presign
+     * URL 생성 후 저장
+     * 서버 { key, putUrl, publicUrl } 응답
+     * 업로드 URL만 발급
+     * */
+    @PostMapping("/presign")
+    public PresignResponse presign(@RequestBody PresignRequest req){
+        String ct = (req.contentType() == null || req.contentType().isBlank())
+                ? "image/jpeg" : req.contentType();
+        var map = uploadService.presign(req.fileName(), ct);
+        return new PresignResponse(map.get("key"), map.get("putUrl"), map.get("publicUrl"));
+    }
+}

--- a/backend/demo/src/main/java/com/sesac/solbid/domain/Product.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/domain/Product.java
@@ -36,8 +36,11 @@ public class Product extends BaseEntity {
     private List<AuctionEvent> auctionEvents = new ArrayList<>();
 
     //이미지
-    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ProductImage> productImages = new ArrayList<>();
+    @OneToMany(mappedBy = "product",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true)
+    @OrderBy("sortOrder ASC") // 오름차순 정렬
+    private final List<ProductImage> productImages = new ArrayList<>();
 
     @OneToMany(mappedBy = "product")
     List<WishList> wishLists = new ArrayList<>();
@@ -111,5 +114,11 @@ public class Product extends BaseEntity {
         this.modelCode = modelCode;
         this.colorway = colorway;
         this.releaseDate = releaseDate;
+    }
+
+    // 연관관계 편의 메서드
+    public void addImage(ProductImage image) {
+        image.setProduct(this);
+        this.productImages.add(image);
     }
 }

--- a/backend/demo/src/main/java/com/sesac/solbid/domain/ProductImage.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/domain/ProductImage.java
@@ -2,16 +2,14 @@ package com.sesac.solbid.domain;
 
 import com.sesac.solbid.domain.baseentity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor
 @Entity
 @Table(name="product_image" ,
         uniqueConstraints = {
-                // 정렬 충돌 방지 (선택): 같은 상품에서 같은 sort_order 금지
+                // 정렬 충돌 방지: 같은 상품에서 같은 sort_order 금지
                 @UniqueConstraint(name="uk_product_sort", columnNames = {"product_id", "sort_order"})
         }
 )
@@ -23,6 +21,7 @@ public class ProductImage extends BaseEntity {
     private Long imageId;
 
     //이 이미지가 등록된 상품
+    @Setter(AccessLevel.PACKAGE) // 패키지 제한 세터
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="product_id", nullable = false)
     private Product product;
@@ -48,15 +47,13 @@ public class ProductImage extends BaseEntity {
         this.product = product;
         this.filePath = filePath;
         this.fileName = fileName;
-        this.sortOrder = sortOrder;
+        this.sortOrder = sortOrder; // Integer -> int 자동 언박싱
         this.isThumbnail = isThumbnail;
     }
 
-    // 런타임 URL 조합 (직접 S3 or CloudFront)
-    @Transient
-    public String getPublicUrl(String baseUrl) {
-        // baseUrl 예: https://cdn.yourapp.com/  또는  https://{bucket}.s3.ap-northeast-2.amazonaws.com/
-        if (baseUrl.endsWith("/")) return baseUrl + filePath;
-        return baseUrl + "/" + filePath;
+
+    public void updateFilePath(String newKey) {
+        this.filePath = newKey;
     }
 }
+

--- a/backend/demo/src/main/java/com/sesac/solbid/dto/upload/request/PresignRequest.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/dto/upload/request/PresignRequest.java
@@ -1,0 +1,6 @@
+package com.sesac.solbid.dto.upload.request;
+
+public record PresignRequest(
+        String fileName,
+        String contentType
+) {}

--- a/backend/demo/src/main/java/com/sesac/solbid/dto/upload/response/FinalizeImagesResponse.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/dto/upload/response/FinalizeImagesResponse.java
@@ -1,0 +1,3 @@
+package com.sesac.solbid.dto.upload.response;
+
+public record FinalizeImagesResponse(Long productId, boolean finalized) {}

--- a/backend/demo/src/main/java/com/sesac/solbid/dto/upload/response/PresignResponse.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/dto/upload/response/PresignResponse.java
@@ -1,0 +1,7 @@
+package com.sesac.solbid.dto.upload.response;
+
+public record PresignResponse(
+        String key,
+        String putUrl,
+        String publicUrl
+) {}

--- a/backend/demo/src/main/java/com/sesac/solbid/exception/ErrorCode.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/exception/ErrorCode.java
@@ -49,7 +49,13 @@ public enum ErrorCode {
     THUMBNAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "중복된 썸네일입니다."),
     SORT_ORDER_DUPLICATED(HttpStatus.BAD_REQUEST, "정렬 순서가 중복되었습니다."),
     INVALID_IMAGE_KEY(HttpStatus.BAD_REQUEST, "잘못된 이미지 키입니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다.");
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+
+    // S3 관련 에러
+    S3_IO_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3 입출력 처리 중 오류가 발생했습니다."),
+    UNSUPPORTED_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 Content-Type 입니다. (image/jpeg, image/png만 허용)"),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "대상을 찾을 수 없습니다.");
+
 
     private final HttpStatus status;
     private final String message;

--- a/backend/demo/src/main/java/com/sesac/solbid/infra/S3ObjectMover.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/infra/S3ObjectMover.java
@@ -1,0 +1,75 @@
+package com.sesac.solbid.infra;
+
+import com.sesac.solbid.exception.CustomException;
+import com.sesac.solbid.exception.ErrorCode;
+import com.sesac.solbid.upload.KeyFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.MetadataDirective;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3ObjectMover {
+
+    private final S3Client s3;
+    private final KeyFactory keyFactory;
+
+    @Value("${app.s3.bucket}")
+    private String bucket;
+
+    private static final String KEY_PREFIX = "products/";
+    private static final String TMP_PREFIX = KEY_PREFIX + "tmp/";
+
+    /**
+     * tmp 경로(products/tmp/...)면 products/{productId}/... 로 이동(copy+delete) 후 새 키를 반환.
+     * tmp가 아니면 원래 키 그대로 반환.
+     */
+    public String moveTmpToFinal(String key, Long productId) {
+        if (key == null || !key.startsWith(KEY_PREFIX)) {
+            throw new CustomException(ErrorCode.INVALID_IMAGE_KEY);
+        }
+        if (!key.startsWith(TMP_PREFIX)) {
+            return key; // 이미 최종 경로
+        }
+
+        String newKey = keyFactory.finalKey(productId, key);
+
+        try {
+            CopyObjectRequest copyReq = CopyObjectRequest.builder()
+                    .sourceBucket(bucket)
+                    .sourceKey(key)
+                    .destinationBucket(bucket)
+                    .destinationKey(newKey)
+                    .metadataDirective(MetadataDirective.COPY) // 메타 유지 명시
+                    .build();
+            s3.copyObject(copyReq);
+
+            // 검증
+            s3.headObject(HeadObjectRequest.builder().bucket(bucket).key(newKey).build());
+
+            // 삭제 (실패는 경고)
+            try {
+                s3.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(key).build());
+            } catch (S3Exception delEx) {
+                log.warn("S3 delete tmp failed (will be cleaned later). key={} msg={}", key, delEx.getMessage());
+            }
+
+            log.info("S3 moved: {} -> {}", key, newKey);
+            return newKey;
+
+        } catch (S3Exception e) {
+            log.error("S3 move failed. from={} to={} (bucket={}) msg={}", key, newKey, bucket, e.getMessage(), e);
+            throw new CustomException(ErrorCode.S3_IO_ERROR);
+        }
+    }
+}
+

--- a/backend/demo/src/main/java/com/sesac/solbid/infra/S3ObjectVerifier.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/infra/S3ObjectVerifier.java
@@ -1,0 +1,47 @@
+package com.sesac.solbid.infra;
+
+import com.sesac.solbid.exception.CustomException;
+import com.sesac.solbid.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3ObjectVerifier {
+
+    private final S3Client s3;
+
+    @Value("${app.s3.bucket}")
+    private String bucket;
+
+    /** S3에 객체가 실제로 존재하는지 HEAD로 확인.
+     * 없으면 INVALID_IMAGE_KEY */
+    public void requireExists(String key) {
+        if (key == null || !key.startsWith("products/")) {
+            throw new CustomException(ErrorCode.INVALID_IMAGE_KEY);
+        }
+        try {
+            s3.headObject(HeadObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build());
+        } catch (AwsServiceException e) { // 4xx/5xx
+            String code = e.awsErrorDetails() != null ? e.awsErrorDetails().errorCode() : "N/A";
+            Integer status = e.statusCode();
+            String reqId = e.requestId();
+            log.warn("S3 headObject failed. bucket={}, key={}, status={}, code={}, reqId={}, msg={}",
+                    bucket, key, status, code, reqId, e.getMessage(), e);
+            throw new CustomException(ErrorCode.INVALID_IMAGE_KEY);
+        } catch (SdkClientException e) {
+            log.error("S3 headObject client error. bucket={}, key={}, msg={}", bucket, key, e.getMessage(), e);
+            throw new CustomException(ErrorCode.S3_IO_ERROR);
+        }
+    }
+}

--- a/backend/demo/src/main/java/com/sesac/solbid/service/ProductImageService.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/ProductImageService.java
@@ -12,10 +12,12 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class ProductImageService {
     private final ProductImageRepository productImageRepository;
-    private final S3Service s3Service;
+    private final S3StorageService s3StorageService;
 
+    /** 서버에서 직접 S3에 업로드하고 public URL을 리턴 (기존 시그니처 유지)
+     * -> 현재는 클라이언트에서 직접 S3로 업로드 하기 때문에 서버 이미지 저장은 후에 추가 예정 */
     public String upload(MultipartFile file) throws IOException {
-        return s3Service.upload(file);
+        return s3StorageService.uploadAndReturnPublicUrl(file);
     }
 
     public void save(ProductImage productImage) {

--- a/backend/demo/src/main/java/com/sesac/solbid/service/ProductService.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/ProductService.java
@@ -6,8 +6,7 @@ import com.sesac.solbid.dto.product.request.ProductCreateRequest;
 import com.sesac.solbid.dto.product.response.ProductResponse;
 
 public interface ProductService {
-
     Long create(Long sellerId, ProductCreateRequest req);
-
+    void finalizeImages(Long id, Long userId);
     List<ProductResponse> getProducts();
 }

--- a/backend/demo/src/main/java/com/sesac/solbid/service/ProductServiceImpl.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/ProductServiceImpl.java
@@ -7,6 +7,8 @@ import com.sesac.solbid.dto.product.request.ProductCreateRequest;
 import com.sesac.solbid.dto.product.response.ProductResponse;
 import com.sesac.solbid.exception.CustomException;
 import com.sesac.solbid.exception.ErrorCode;
+import com.sesac.solbid.infra.S3ObjectMover;
+import com.sesac.solbid.infra.S3ObjectVerifier;
 import com.sesac.solbid.mapper.ProductImageMapper;
 import com.sesac.solbid.mapper.ProductMapper;
 import com.sesac.solbid.repository.ProductRepository;
@@ -26,22 +28,27 @@ import java.util.stream.Collectors;
 @Slf4j
 public class ProductServiceImpl implements ProductService {
 
-    private static final String S3_KEY_PREFIX = "products/";
+    private static final String TMP_PREFIX = "products/tmp/"; // tmp: 보안 강화
 
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
     private final ProductMapper productMapper;           // MapStruct
     private final ProductImageMapper productImageMapper; // MapStruct
 
+    // S3 검증/이동 컴포넌트
+    private final S3ObjectVerifier s3ObjectVerifier;     // S3 HEAD 존재 확인
+    private final S3ObjectMover s3ObjectMover;           // tmp → 최종 경로 이동(Copy+Delete)
+
     /**
      * 상품 등록
-     * - 검증: 썸네일 ≤ 1, sortOrder 중복 금지, S3 key prefix
+     * - 검증: 썸네일 ≤ 1, sortOrder 중복 금지, S3 key prefix + S3 존재 확인
      * - 처리: DTO → 엔티티 매핑(MapStruct) 후 저장
      * @throws CustomException 인증/검증 실패 시
      */
     @Override
     @Transactional
     public Long create(Long sellerId, ProductCreateRequest req) {
+
         // 판매자 조회
         User seller = userRepository.findById(sellerId)
                 .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED));
@@ -62,6 +69,11 @@ public class ProductServiceImpl implements ProductService {
         Long id = productRepository.save(product).getProductId();
         log.info("Product created: id={} sellerId={} name={}", id, sellerId, req.name());
         return id;
+    }
+
+    @Override
+    public void finalizeImages(Long id, Long userId) {
+
     }
 
     //디버깅 로그
@@ -87,10 +99,14 @@ public class ProductServiceImpl implements ProductService {
                 log.warn("sortOrder duplicated: {}", img.sortOrder());
                 throw new CustomException(ErrorCode.SORT_ORDER_DUPLICATED);
             }
-            if (img.filePath() == null || !img.filePath().startsWith(S3_KEY_PREFIX)) {
-                log.warn("invalid image key: {}", img.filePath());
+            if (img.filePath() == null || !img.filePath().startsWith(TMP_PREFIX)) {
+                log.warn("only tmp keys allowed: {}", img.filePath());
                 throw new CustomException(ErrorCode.INVALID_IMAGE_KEY);
             }
+
+
+            // S3에 객체가 존재하는지 확인 (PUT 실패/위조 키 차단)
+            s3ObjectVerifier.requireExists(img.filePath());
         }
     }
 

--- a/backend/demo/src/main/java/com/sesac/solbid/service/S3PresignServiceImpl.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/S3PresignServiceImpl.java
@@ -1,0 +1,52 @@
+package com.sesac.solbid.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+import java.time.Duration;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class S3PresignServiceImpl implements S3Service {
+
+    private final S3Presigner presigner;
+
+    @Value("${app.s3.bucket}")
+    private String bucket;
+
+    @Value("${app.s3.presign.expire-minutes:15}")
+    private long defaultExpireMinutes;
+
+    @Override
+    public String presignPutUrl(String key, String contentType) {
+        return presignPutUrl(key, contentType, defaultExpireMinutes);
+    }
+
+    @Override
+    public String presignPutUrl(String key, String contentType, long expireMinutes) {
+        Objects.requireNonNull(key, "key must not be null");
+        Objects.requireNonNull(contentType, "contentType must not be null");
+
+        PutObjectRequest put = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .contentType(contentType)
+                .build();
+
+        // 요청: PutObjectPresignRequest
+        PutObjectPresignRequest req = PutObjectPresignRequest.builder()
+                .putObjectRequest(put)
+                .signatureDuration(Duration.ofMinutes(expireMinutes))
+                .build();
+
+        // 응답: PresignedPutObjectRequest
+        PresignedPutObjectRequest presigned = presigner.presignPutObject(req);
+        return presigned.url().toString();
+    }
+}

--- a/backend/demo/src/main/java/com/sesac/solbid/service/S3Service.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/S3Service.java
@@ -1,62 +1,8 @@
 package com.sesac.solbid.service;
 
-import com.sesac.solbid.util.S3MultipartFile;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-import software.amazon.awssdk.core.ResponseBytes;
-import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-
-import java.io.IOException;
-import java.util.UUID;
-
-@Service
-@RequiredArgsConstructor
-public class S3Service {
-
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
-
-    private final S3Client s3Client = S3Client.builder()
-            .region(Region.AP_SOUTHEAST_2)
-            .build();
-
-    public String upload(MultipartFile file) throws IOException {
-        String fileName = UUID.randomUUID() + "-" + file.getOriginalFilename();
-
-        s3Client.putObject(
-                PutObjectRequest.builder()
-                        .bucket(bucket)
-                        .key(fileName)
-                        .acl(ObjectCannedACL.PUBLIC_READ)
-                        .contentType(file.getContentType())
-                        .build(),
-                RequestBody.fromInputStream(file.getInputStream(), file.getSize())
-        );
-
-        return "https://" + bucket + ".s3.ap-southeast-2.amazonaws.com/" + fileName;
-    }
-
-    public MultipartFile download(String fileName) throws IOException {
-        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
-                .bucket(bucket)
-                .key(fileName)
-                .build();
-
-        ResponseBytes<GetObjectResponse> objectBytes =
-                s3Client.getObjectAsBytes(getObjectRequest);
-
-        return new S3MultipartFile(
-                objectBytes.asByteArray(), // byte[]
-                fileName, // original filename
-                objectBytes.response().contentType() // content-type
-        );
+public interface S3Service {
+    String presignPutUrl(String key, String contentType);
+    default String presignPutUrl(String key, String contentType, long expireMinutes) {
+        return presignPutUrl(key, contentType);
     }
 }

--- a/backend/demo/src/main/java/com/sesac/solbid/service/S3StorageService.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/S3StorageService.java
@@ -1,0 +1,17 @@
+package com.sesac.solbid.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface S3StorageService {
+    /** 서버에서 직접 업로드하고 '키'를 반환 */
+    String uploadAndReturnKey(MultipartFile file);
+
+    /** (호환용) 서버 업로드 후 Public URL 반환 */
+    String uploadAndReturnPublicUrl(MultipartFile file);
+
+    /** 키로 다운로드하여 MultipartFile 형태 반환 */
+    org.springframework.web.multipart.MultipartFile download(String key);
+
+    /** 키로 퍼블릭 URL 구성(cdnBase 있으면 CDN, 없으면 S3 URL) */
+    String buildPublicUrl(String key);
+}

--- a/backend/demo/src/main/java/com/sesac/solbid/service/S3StorageServiceImpl.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/S3StorageServiceImpl.java
@@ -1,0 +1,99 @@
+package com.sesac.solbid.service;
+
+import com.sesac.solbid.exception.CustomException;
+import com.sesac.solbid.exception.ErrorCode;
+import com.sesac.solbid.upload.KeyFactory;
+import com.sesac.solbid.util.S3MultipartFile;
+import com.sesac.solbid.util.UploadPolicy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.io.IOException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3StorageServiceImpl implements S3StorageService {
+
+    @Value("${app.s3.bucket}")
+    private String bucket;
+
+    @Value("${app.s3.region:ap-northeast-2}")
+    private String region;
+
+    @Value("${app.cdn.base-url:}")
+    private String cdnBase;
+
+    @Value("${app.s3.server-upload.public-read:false}")
+    private boolean publicRead;
+
+    private final S3Client s3Client;
+    private final KeyFactory keyFactory;
+
+    @Override
+    public String uploadAndReturnKey(MultipartFile file) {
+        try {
+            String contentType = file.getContentType();
+            UploadPolicy.requireAllowed(contentType);
+            String ext = UploadPolicy.extOf(contentType);
+
+            String key = keyFactory.tmpKey(ext); // tmp로 올리고 나중에 finalize 이동
+
+            PutObjectRequest.Builder pob = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .contentType(contentType);
+            if (publicRead) {
+                pob.acl(ObjectCannedACL.PUBLIC_READ); // 필요시에만 public
+            }
+
+            s3Client.putObject(pob.build(),
+                    RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+            log.info("S3 upload ok: key={}", key);
+            return key;
+        } catch (IOException e) {
+            log.error("S3 upload IO error", e);
+            throw new CustomException(ErrorCode.S3_IO_ERROR);
+        } catch (S3Exception e) {
+            log.error("S3 upload failed: {}", e.awsErrorDetails() != null ? e.awsErrorDetails().errorMessage() : e.getMessage(), e);
+            throw new CustomException(ErrorCode.S3_IO_ERROR);
+        }
+    }
+
+    @Override
+    public String uploadAndReturnPublicUrl(MultipartFile file) {
+        String key = uploadAndReturnKey(file);
+        return buildPublicUrl(key);
+    }
+
+    @Override
+    public MultipartFile download(String key) {
+        try {
+            var getReq = GetObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+            ResponseBytes<GetObjectResponse> bytes = s3Client.getObjectAsBytes(getReq);
+            return new S3MultipartFile(bytes.asByteArray(), key, bytes.response().contentType());
+        } catch (S3Exception e) {
+            log.error("S3 download failed: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.S3_IO_ERROR);
+        }
+    }
+
+    @Override
+    public String buildPublicUrl(String key) {
+        if (cdnBase != null && !cdnBase.isBlank()) {
+            return cdnBase.endsWith("/") ? cdnBase + key : cdnBase + "/" + key;
+        }
+        return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + key;
+    }
+}

--- a/backend/demo/src/main/java/com/sesac/solbid/service/UploadService.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/UploadService.java
@@ -1,0 +1,7 @@
+package com.sesac.solbid.service;
+
+import java.util.Map;
+
+public interface UploadService {
+    Map<String, String> presign(String fileName, String contentType);
+}

--- a/backend/demo/src/main/java/com/sesac/solbid/service/UploadServiceImpl.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/UploadServiceImpl.java
@@ -1,0 +1,54 @@
+package com.sesac.solbid.service;
+
+import com.sesac.solbid.util.UploadPolicy;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class UploadServiceImpl implements UploadService {
+
+    private final S3Service s3Service;
+
+    @Value("${app.s3.bucket}")
+    private String bucket;
+
+    @Value("${app.s3.region:ap-northeast-2}")
+    private String region;
+
+    @Value("${app.cdn.base-url:}")
+    private String cdnBase;
+
+    @Override
+    public Map<String, String> presign(String fileName, String contentType) {
+        UploadPolicy.requireAllowed(contentType);
+        String ext = UploadPolicy.extOf(contentType);
+
+        YearMonth ym = YearMonth.now(ZoneId.of("Asia/Seoul"));
+        String key = "products/tmp/%d%02d/%s.%s".formatted(
+                ym.getYear(), ym.getMonthValue(), UUID.randomUUID(), ext
+        );
+
+        String putUrl = s3Service.presignPutUrl(key, contentType);
+        String publicUrl = buildPublicUrl(key);
+
+        return Map.of(
+                "key", key,
+                "putUrl", putUrl,
+                "publicUrl", publicUrl
+        );
+    }
+
+    private String buildPublicUrl(String key) {
+        if (cdnBase != null && !cdnBase.isBlank()) {
+            return cdnBase.endsWith("/") ? cdnBase + key : cdnBase + "/" + key;
+        }
+        return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + key;
+    }
+}

--- a/backend/demo/src/main/java/com/sesac/solbid/upload/KeyFactory.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/upload/KeyFactory.java
@@ -1,0 +1,35 @@
+package com.sesac.solbid.upload;
+
+import org.springframework.stereotype.Component;
+
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+/**
+ * 업로드/최종 저장 키 생성기
+ */
+@Component
+public class KeyFactory {
+
+    private static final String KEY_PREFIX = "products/";
+    private static final String TMP_PREFIX  = KEY_PREFIX + "tmp/";
+    private static final DateTimeFormatter YM = DateTimeFormatter.ofPattern("yyyyMM");
+    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+
+    /** 임시 키: products/tmp/{yyyyMM}/{uuid}.{ext} */
+    public String tmpKey(String ext) {
+        String yyyymm = YearMonth.now(ZONE).format(YM);
+        String uuid = UUID.randomUUID().toString();
+        return TMP_PREFIX + yyyymm + "/" + uuid + "." + ext;
+    }
+
+    /** 최종 키: products/{productId}/{yyyyMM}/{uuid}.{ext} */
+    public String finalKey(Long productId, String tmpKey) {
+        // tmpKey에서 "products/tmp/" 이후 경로(yyyyMM/uuid.ext)를 그대로 보존
+        String suffix = tmpKey.substring(TMP_PREFIX.length());
+        return KEY_PREFIX + productId + "/" + suffix;
+    }
+
+}

--- a/backend/demo/src/main/java/com/sesac/solbid/util/UploadPolicy.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/util/UploadPolicy.java
@@ -1,0 +1,37 @@
+package com.sesac.solbid.util;
+
+import com.sesac.solbid.exception.CustomException;
+import com.sesac.solbid.exception.ErrorCode;
+
+
+import java.util.Set;
+
+public class UploadPolicy {
+    private UploadPolicy() {} // 유틸 클래스로만 사용
+
+    // 허용할 MIME 타입
+    public static final Set<String> ALLOWED_TYPES = Set.of(
+            "image/jpeg",
+            "image/png"
+    );
+
+    /** 허용 타입인지 검사 (아니면 예외) */
+    public static void requireAllowed(String contentType) {
+        if (contentType == null || !ALLOWED_TYPES.contains(contentType)) {
+            throw new CustomException(ErrorCode.UNSUPPORTED_CONTENT_TYPE);
+        }
+    }
+
+    /** Content-Type → 확장자 매핑 */
+    public static String extOf(String contentType) {
+        if ("image/jpeg".equals(contentType)) return "jpg";
+        if ("image/png".equals(contentType))  return "png";
+        throw new CustomException(ErrorCode.UNSUPPORTED_CONTENT_TYPE);
+    }
+
+    /** 과거 예시 호환용: 파일명은 무시하고 Content-Type 기준으로 통일 */
+    public static String normalizeExt(String contentType, String fileName) {
+        return extOf(contentType);
+    }
+
+}


### PR DESCRIPTION
-presign 발급 및 tmp 키 정책 추가

-S3 검증/이동 인프라

-상품 등록 로직 분리 & 최종화 API

-키 생성 정책 일원화
 refactor(infra): S3ObjectMover가 KeyFactory.finalKey 사용하도록 변경
 
 close #219 