### PR TITLE
chore: 인증 이메일 템플릿에서 불필요한 스팸 안내 문구 제거

### DIFF
--- a/backend/demo/src/main/java/com/sesac/solbid/service/user/EmailService.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/user/EmailService.java
@@ -170,7 +170,6 @@ public class EmailService {
                         <div style="font-size: 32px; font-weight: bold; color: #28a745; letter-spacing: 8px; font-family: 'Courier New', monospace;">%s</div>
                     </div>
                     <p style="margin-bottom: 10px; color: #666; font-size: 14px;">⚠️ 이 인증번호는 5분 후에 만료됩니다.</p>
-                    <p style="margin-bottom: 10px; color: #666; font-size: 14px;">📧 이메일이 스팸 폴더에 있을 수 있으니 확인해주세요.</p>
                     <p style="margin-bottom: 20px; color: #666; font-size: 14px;">🔒 보안을 위해 인증번호를 타인과 공유하지 마세요.</p>
                 </div>
                 <div style="background-color: #f8f9fa; padding: 20px; text-align: center; border-top: 1px solid #dee2e6; font-size: 12px; color: #666;">


### PR DESCRIPTION
**관련 이슈**

- closes #264 

사용자에게 발송되는 인증 이메일의 가독성을 높이고 핵심 내용(인증번호)에 더 집중할 수 있도록, 불필요하다고 판단되는 '스팸 폴더 확인' 안내 문구를 제거합니다.