### PR TITLE
feat(auth): 비밀번호 유효성 검사 규칙 강화

### DIFF
--- a/backend/demo/src/main/java/com/sesac/solbid/dto/user/request/SignupRequest.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/dto/user/request/SignupRequest.java
@@ -19,8 +19,9 @@ public class SignupRequest {
     private String email;
 
     @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
-    @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=\\S+$).{8,20}$",
-            message = "비밀번호는 8~20자 영문 대소문자, 숫자, 특수문자를 사용하세요.")
+    @Pattern(
+            regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!@#$%^&*()_+\\-={}\\[\\]:;\"'`<>,.?/|~])(?=\\S+$).{8,20}$",
+            message = "비밀번호는 8~20자 영문 대소문자, 숫자, 특수문자를 모두 포함하세요.")
     private String password;
 
     @NotBlank(message = "닉네임은 필수 입력 값입니다.")
@@ -44,4 +45,3 @@ public class SignupRequest {
                 .build();
     }
 }
-


### PR DESCRIPTION
**관련 이슈**

- closes #287 

비밀번호 유효성 검사 규칙 변경: 기존의 '영문+숫자' 필수 조건에 '특수문자 포함'을 필수로 추가했습니다.
