### PR TITLE
feat: JWT 인증 적용 및 Javadoc 주석 추가

### DIFF
--- a/backend/demo/src/main/java/com/sesac/solbid/controller/AuctionController.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/controller/AuctionController.java
@@ -1,5 +1,6 @@
 package com.sesac.solbid.controller;
 
+import com.sesac.solbid.domain.User;
 import com.sesac.solbid.dto.auction.request.AuctionCreateRequest;
 import com.sesac.solbid.dto.auction.response.AuctionCreateResponse;
 import com.sesac.solbid.service.auction.AuctionService;
@@ -7,6 +8,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -24,7 +26,7 @@ public class AuctionController {
      * 경매 생성
      * POST /api/auctions
      *
-     * @header X-User-Id  인증된 사용자 ID (Long) -> 후애 JWT 변경
+     * @header JWT
      * @requestBody       AuctionCreateRequest (검증 대상)
      *                    - productId: 경매할 상품 ID
      *                    - startPrice: 시작가
@@ -43,9 +45,11 @@ public class AuctionController {
      */
     @PostMapping(consumes = "application/json", produces = "application/json")
     public ResponseEntity<AuctionCreateResponse> create(
-            @RequestHeader("X-User-Id") Long userId,
+            @AuthenticationPrincipal User authUser,
             @Valid @RequestBody AuctionCreateRequest req
     ) {
+        Long userId = authUser.getUserId();
+
         log.info("POST /api/auctions by userId={} productId={} startPrice={} endAt={}",
                 userId, req.productId(), req.startPrice(), req.endAt());
 

--- a/backend/demo/src/main/java/com/sesac/solbid/controller/PaymentController.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/controller/PaymentController.java
@@ -16,14 +16,16 @@ public class PaymentController {
 
     private final PaymentService paymentService;
 
-    /*
-    * 포트원 결제 요청 준비 */
+    /**
+     * 포트원 결제 요청 준비
+     * POST /charge/prepare
+     *
+     * @param request 결제 준비 요청 DTO
+     * @return 결제 준비 응답 DTO(orderId, redirectUrl 포함)
+     **/
     @PostMapping("/charge/prepare")
     public ResponseEntity<PaymentPrepareResponse> preparePayment(@RequestBody PaymentPrepareRequest request) {
         return ResponseEntity.ok(paymentService.preparePayment(request));
-        /*
-        * 서버에서 고유 orderId 생성
-        * redirectUrl 반환*/
     }
 
     @GetMapping("/ping")

--- a/backend/demo/src/main/java/com/sesac/solbid/controller/PaymentRecordQueryController.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/controller/PaymentRecordQueryController.java
@@ -1,5 +1,6 @@
 package com.sesac.solbid.controller;
 
+import com.sesac.solbid.domain.User;
 import com.sesac.solbid.dto.payment.request.PaymentRecordSearchRequest;
 import com.sesac.solbid.dto.payment.response.PageResponse;
 import com.sesac.solbid.dto.payment.response.PaymentRecordItemResponse;
@@ -11,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,13 +33,13 @@ public class PaymentRecordQueryController {
      * 페이징/정렬:
      *   ?page=0&size=20&sort=requestedAt,desc
      */
-
-
     @GetMapping
     public ResponseEntity<PageResponse<PaymentRecordItemResponse>> list(
             @Valid @ModelAttribute PaymentRecordSearchRequest req,
-            @PageableDefault(size = 20, sort = "requestedAt", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(size = 20, sort = "requestedAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthenticationPrincipal User authUser
     ) {
+        req.setUserId(authUser.getUserId());
         return ResponseEntity.ok(service.getRecords(req, pageable));
     }
 }

--- a/backend/demo/src/main/java/com/sesac/solbid/controller/PointController.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/controller/PointController.java
@@ -1,9 +1,11 @@
 package com.sesac.solbid.controller;
 
+import com.sesac.solbid.domain.User;
 import com.sesac.solbid.dto.payment.response.PointSummaryResponse;
 import com.sesac.solbid.service.PointService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,9 +18,23 @@ public class PointController {
 
     private final PointService pointService;
 
+    /*
+    * 관리자용 유저 아이디 기반 포인트 단건 조회*/
+    /*
     @GetMapping("/{userId}/points")
     public ResponseEntity<PointSummaryResponse> getCurrentPoint(@PathVariable Long userId) {
         PointSummaryResponse body = pointService.getCurrentPoint(userId);
+        return ResponseEntity.ok()
+                .header("Cache-Control", "no-store")
+                .body(body);
+    }*/
+
+    /*사용자용 유저 아이디 기반 포인트 단건 조회*/
+    @GetMapping("/me/points")
+    public ResponseEntity<PointSummaryResponse> getMyPoint(
+            @AuthenticationPrincipal User authUser) {
+
+        PointSummaryResponse body = pointService.getCurrentPoint(authUser.getUserId());
         return ResponseEntity.ok()
                 .header("Cache-Control", "no-store")
                 .body(body);

--- a/backend/demo/src/main/java/com/sesac/solbid/controller/PointController.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/controller/PointController.java
@@ -29,7 +29,13 @@ public class PointController {
                 .body(body);
     }*/
 
-    /*사용자용 유저 아이디 기반 포인트 단건 조회*/
+    /**
+     * 로그인한 사용자 본인의 포인트 단건 조회
+     * GET /me/points
+     *
+     * @param authUser 현재 인증된 사용자 객체
+     * @return 사용자의 포인트 요약 응답
+     **/
     @GetMapping("/me/points")
     public ResponseEntity<PointSummaryResponse> getMyPoint(
             @AuthenticationPrincipal User authUser) {

--- a/backend/demo/src/main/java/com/sesac/solbid/controller/PortOneController.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/controller/PortOneController.java
@@ -19,6 +19,7 @@ public class PortOneController {
     private final PaymentService paymentService;
 
     // 액세스 토큰 테스트용 API
+
     @GetMapping("/token")
     public ResponseEntity<String> getToken() {
         String token = portOneService.getAccessToken();
@@ -45,8 +46,13 @@ public class PortOneController {
 */
 
 
-    // imp_uid 기반 결제 승인 및 처리
-    @GetMapping("/approve")
+    /**
+     * imp_uid 기반 결제 승인 및 처리
+     * GET /approve?impUid={imp_uid}
+     *
+     * @param impUid PortOne 결제 고유 ID
+     * @return 처리 결과 문자열
+     **/    @GetMapping("/approve")
     public ResponseEntity<String> approve(@RequestParam String impUid) {
         String token = portOneService.getAccessToken();
         String result = paymentService.handlePaymentSuccess(impUid, token);

--- a/backend/demo/src/main/java/com/sesac/solbid/controller/ProductController.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/controller/ProductController.java
@@ -1,5 +1,6 @@
 package com.sesac.solbid.controller;
 
+import com.sesac.solbid.domain.User;
 import com.sesac.solbid.dto.ApiResponse;
 import com.sesac.solbid.dto.product.request.ProductCreateRequest;
 import com.sesac.solbid.dto.product.response.ProductCreateResponse;
@@ -8,6 +9,7 @@ import com.sesac.solbid.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,38 +23,30 @@ public class ProductController {
 
     private final ProductService productService;
 
-    /*
+    /**
      * 상품 등록
-     * POST /api/products
+     * * POST /api/products
      *
-     * @param userId 인증된 사용자 ID (JWT 필터에서 추출됨)
-     * @param req    상품 등록 요청 DTO
-     * @return 201 Created + { productId }
+     * @param authUser 인증된 사용자 정보 (로그인된 회원)
+     * @param req      상품 등록 요청 본문 (상품명, 이미지 목록 등)
+     * @return 생성된 상품의 ID를 담은 응답 (201 Created)
      *
-     * 검증 규칙:
-     * - size 220~320
-     * - images ≤ 5, 썸네일 ≤ 1
-     * - sortOrder 중복 불가
-     * - filePath는 "products/" prefix
+     * 사용자가 전달한 상품 정보(ProductCreateRequest)를 기반으로
+     * 새로운 상품을 생성한다.
+     * 생성 과정에서 인증 사용자 ID를 함께 기록하며,
+     * 등록된 상품의 고유 ID를 반환한다.
      * */
+    @PostMapping public ResponseEntity<?> create(
+            @AuthenticationPrincipal User authUser,
+            @Validated @RequestBody ProductCreateRequest req
+    ) {
+        Long userId = authUser.getUserId();
+        log.info("POST /api/products by userId={} name={} images={}", userId, req.name(),
+                req.images() != null ? req.images().size() : 0);
 
-    /* 테스트 코드
-    @PostMapping
-    public ResponseEntity<?> create(@RequestAttribute("userId") Long userId,  // or @AuthUser 커스텀 리졸버
-                                    @Validated @RequestBody ProductCreateRequest req) {
-        Long id = productService.create(userId, req);
-        return ResponseEntity.status(201).body(new ProductCreateResponse(id));
-    }
-
-    private record ProductCreateResponse(Long productId) {}
-    */
-
-    // JWT 필터 붙이고 다시 @RequestAttribute("userId")로 원복
-    @PostMapping
-    public ResponseEntity<?> create(@RequestHeader("X-User-Id") Long userId, @Validated @RequestBody ProductCreateRequest req) {
-        log.info("POST /api/products by userId={} name={} images={}", userId, req.name(), req.images() != null ? req.images().size() : 0);
         Long id = productService.create(userId, req);
         log.info("Product created: id={} by userId={}", id, userId);
+
         return ResponseEntity.status(201).body(new ProductCreateResponse(id));
     }
 

--- a/backend/demo/src/main/java/com/sesac/solbid/controller/ProductFinalizeController.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/controller/ProductFinalizeController.java
@@ -1,9 +1,11 @@
 package com.sesac.solbid.controller;
 
+import com.sesac.solbid.domain.User;
 import com.sesac.solbid.dto.upload.response.FinalizeImagesResponse;
 import com.sesac.solbid.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -18,15 +20,18 @@ public class ProductFinalizeController {
      * 상품 이미지 최종 확정
      * POST /{id}/finalize-images
      *
-     * @param id     상품 ID
-     * @param userId 요청자 사용자 ID (X-User-Id 헤더)
+     * @param id 상품 ID
+     * @param authUser 인증된 사용자 (JWT 인증 객체)
      * @return 최종 확정 완료 여부와 상품 ID
      */
     @PostMapping("/{id}/finalize-images")
     public ResponseEntity<FinalizeImagesResponse> finalizeImages(
             @PathVariable Long id,
-            @RequestHeader("X-User-Id") Long userId) {
+            @AuthenticationPrincipal User authUser
+    ) {
+        Long userId = authUser.getUserId();
         productService.finalizeImages(id, userId);
         return ResponseEntity.ok(new FinalizeImagesResponse(id, true));
     }
+
 }

--- a/backend/demo/src/main/java/com/sesac/solbid/controller/UploadController.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/controller/UploadController.java
@@ -30,9 +30,13 @@ public class UploadController {
 
     private final UploadService uploadService;
 
-    /*
+    /**
      * 파일 업로드용 Presigned URL 발급
-     * POST /presign
+     * POST /api/uploads/presign
+     *
+     * @param req 파일 이름 및 Content-Type을 담은 요청 DTO
+     * @return key, putUrl, publicUrl을 담은 {@link PresignResponse}
+     *
      * URL 생성 후 저장
      * 서버 { key, putUrl, publicUrl } 응답
      * 업로드 URL만 발급

--- a/backend/demo/src/main/java/com/sesac/solbid/dto/payment/request/PaymentRecordSearchRequest.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/dto/payment/request/PaymentRecordSearchRequest.java
@@ -11,7 +11,9 @@ import java.time.LocalDate;
 @Getter
 @Setter
 public class PaymentRecordSearchRequest {
+    /*
     @NotNull(message = "userId는 필수입니다.")
+    private Long userId;*/
     private Long userId;
 
     private PaymentStatus status; // SUCCESS/FAIL/...

--- a/backend/demo/src/main/java/com/sesac/solbid/service/PaymentRecordQueryService.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/PaymentRecordQueryService.java
@@ -6,5 +6,6 @@ import com.sesac.solbid.dto.payment.response.PaymentRecordItemResponse;
 import org.springframework.data.domain.Pageable;
 
 public interface PaymentRecordQueryService {
+    /**사용자 결제 내역 조회*/
     PageResponse<PaymentRecordItemResponse> getRecords(PaymentRecordSearchRequest req, Pageable pageable);
 }

--- a/backend/demo/src/main/java/com/sesac/solbid/service/PaymentRecordQueryServiceImpl.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/PaymentRecordQueryServiceImpl.java
@@ -29,6 +29,7 @@ class PaymentRecordQueryServiceImpl implements PaymentRecordQueryService {
     // 허용 정렬 필드 (화이트리스트)
     private static final Set<String> ALLOWED_SORT = Set.of("requestedAt", "amount", "paymentStatus");
 
+    /**사용자 결제 내역 조회*/
     @Override
     public PageResponse<PaymentRecordItemResponse> getRecords(PaymentRecordSearchRequest req, Pageable pageable) {
         Assert.notNull(req.getUserId(), "userId is required");

--- a/backend/demo/src/main/java/com/sesac/solbid/service/PaymentService.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/PaymentService.java
@@ -6,9 +6,9 @@ import com.sesac.solbid.dto.payment.response.PaymentPrepareResponse;
 
 public interface PaymentService {
 
-    //결제 준비
+    /**결제 준비*/
     PaymentPrepareResponse preparePayment(PaymentPrepareRequest request);
-    //결제 승인
+    /**결제 승인*/
     String handlePaymentSuccess(String impUid, String token);
 
 

--- a/backend/demo/src/main/java/com/sesac/solbid/service/PointService.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/PointService.java
@@ -3,5 +3,6 @@ package com.sesac.solbid.service;
 import com.sesac.solbid.dto.payment.response.PointSummaryResponse;
 
 public interface PointService {
+    /**유저 포인트 단건 조회*/
     PointSummaryResponse getCurrentPoint(Long userId);
 }

--- a/backend/demo/src/main/java/com/sesac/solbid/service/PointServiceImpl.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/PointServiceImpl.java
@@ -16,6 +16,7 @@ public class PointServiceImpl implements PointService {
 
     private final UserRepository userRepository;
 
+    /**유저 포인트 단건 조회*/
     @Override
     @Transactional(readOnly = true)
     public PointSummaryResponse getCurrentPoint(Long userId) {

--- a/backend/demo/src/main/java/com/sesac/solbid/service/PortOneService.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/PortOneService.java
@@ -5,9 +5,9 @@ import com.sesac.solbid.dto.payment.response.PortOnePaymentResponse;
 
 public interface PortOneService {
 
-    // 결제 승인 토큰
+    /**결제 승인 토큰*/
     String getAccessToken();
-    // 결제 승인 준비
+    /**결제 승인 준비*/
     PortOnePaymentResponse.PaymentData approvePayment(String impUid, String accessToken);
 
 

--- a/backend/demo/src/main/java/com/sesac/solbid/service/PortOneServiceImpl.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/PortOneServiceImpl.java
@@ -23,7 +23,7 @@ public class PortOneServiceImpl implements PortOneService {
     @Value("${portone.api-secret}")
     private String apiSecret;
 
-    /* 결제 승인 토큰 요청*/
+    /** 결제 승인 토큰 요청*/
     @Override
     public String getAccessToken() {
         log.info("[PortOne] 액세스 토큰 요청 시작");
@@ -53,7 +53,7 @@ public class PortOneServiceImpl implements PortOneService {
     }
 
 
-    /* 결제 승인 테스트 1 : 토큰 기반
+    /** 결제 승인 테스트 1 : 토큰 기반
     @Override
     public String approvePayment(String impUid, String accessToken) {
         log.info("[PortOne] 결제 승인 조회 요청 시작, imp_uid={}", impUid);
@@ -75,10 +75,9 @@ public class PortOneServiceImpl implements PortOneService {
 
         return data.getStatus(); // 필요시 DB 업데이트도 함께 수행 가능
     }
-
     */
 
-    // 결제 승인 테스트 2 :imp_uid 기반
+    /**결제 승인 테스트 2 :imp_uid 기반 */
     @Override
     public PortOnePaymentResponse.PaymentData approvePayment(String impUid, String accessToken) {
         log.info("[PortOne] 결제 상태 조회 요청: impUid={}", impUid);
@@ -114,9 +113,4 @@ public class PortOneServiceImpl implements PortOneService {
 
         return data;
     }
-
-
-
-
-
 }

--- a/backend/demo/src/main/java/com/sesac/solbid/service/ProductService.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/ProductService.java
@@ -9,9 +9,10 @@ public interface ProductService {
 
     Long create(Long sellerId, ProductCreateRequest req);
 
+    /**상품 등록 이미지 최종 확정*/
     void finalizeImages(Long id, Long userId);
 
-    /** 경매가 하나라도 있으면 판매자 변경 불가 */
+    /**경매가 하나라도 있으면 판매자 변경 불가*/
     void changeSeller(Long productId, Long newSellerId);
 
     List<ProductResponse> getProducts(String sortBy, Integer limit);

--- a/backend/demo/src/main/java/com/sesac/solbid/service/ProductServiceImpl.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/ProductServiceImpl.java
@@ -75,6 +75,7 @@ public class ProductServiceImpl implements ProductService {
         return id;
     }
 
+    /**상품 이미지 최종 확정*/
     @Override
     public void finalizeImages(Long id, Long userId) {
     }
@@ -113,6 +114,7 @@ public class ProductServiceImpl implements ProductService {
         }
     }
 
+    /**상품의 판매자를 다른 사용자로 변경*/
     @Override
     @Transactional
     public void changeSeller(Long productId, Long newSellerId) {

--- a/backend/demo/src/main/java/com/sesac/solbid/service/S3PresignServiceImpl.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/S3PresignServiceImpl.java
@@ -33,6 +33,7 @@ public class S3PresignServiceImpl implements S3Service {
     @Value("${app.s3.presign.expire-minutes:15}")
     private long defaultExpireMinutes;
 
+    /**Presigned S3 업로드 Key 발급*/
     @Override
     public String presignPutUrl(String key, String contentType) {
         try {

--- a/backend/demo/src/main/java/com/sesac/solbid/service/S3Service.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/S3Service.java
@@ -1,6 +1,8 @@
 package com.sesac.solbid.service;
 
 public interface S3Service {
+
+    /**Presigned S3 업로드 Key 발급*/
     String presignPutUrl(String key, String contentType);
     default String presignPutUrl(String key, String contentType, long expireMinutes) {
         return presignPutUrl(key, contentType);

--- a/backend/demo/src/main/java/com/sesac/solbid/service/S3StorageServiceImpl.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/S3StorageServiceImpl.java
@@ -37,6 +37,7 @@ public class S3StorageServiceImpl implements S3StorageService {
     private final S3Client s3Client;
     private final KeyFactory keyFactory;
 
+    /**MultipartFile을 S3에 업로드 후 생성된 Key 반환 (임시 경로에 저장됨)*/
     @Override
     public String uploadAndReturnKey(MultipartFile file) {
         try {
@@ -68,12 +69,14 @@ public class S3StorageServiceImpl implements S3StorageService {
         }
     }
 
+    /**MultipartFile을 S3에 업로드 후 Public URL 반환.*/
     @Override
     public String uploadAndReturnPublicUrl(MultipartFile file) {
         String key = uploadAndReturnKey(file);
         return buildPublicUrl(key);
     }
 
+    /**S3에서 key 기반으로 객체 다운로드 후 MultipartFile로 반환.*/
     @Override
     public MultipartFile download(String key) {
         try {
@@ -89,6 +92,8 @@ public class S3StorageServiceImpl implements S3StorageService {
         }
     }
 
+    /**주어진 S3 key에 대한 Public URL 생성.
+     * CDN이 설정되어 있으면 CDN base URL을, 없으면 기본 S3 URL을 반환.*/
     @Override
     public String buildPublicUrl(String key) {
         if (cdnBase != null && !cdnBase.isBlank()) {

--- a/backend/demo/src/main/java/com/sesac/solbid/service/UploadService.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/UploadService.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 
 public interface UploadService {
+    /**업로드용 Presigned URL을 발급*/
     Map<String, String> presign(String fileName, String contentType);
+    /**S3 이미지 key 목록 다운로드 URL 생성*/
     Map<String, String> getDownloadUrls(List<String> imageKeys);
 }

--- a/backend/demo/src/main/java/com/sesac/solbid/service/UploadServiceImpl.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/UploadServiceImpl.java
@@ -30,6 +30,7 @@ public class UploadServiceImpl implements UploadService {
     @Value("${app.cdn.base-url:}")
     private String cdnBase;
 
+    /**업로드용 Presigned URL 발급*/
     @Override
     public Map<String, String> presign(String fileName, String contentType) {
         UploadPolicy.requireAllowed(contentType);
@@ -57,6 +58,7 @@ public class UploadServiceImpl implements UploadService {
                 .collect(Collectors.toMap(Function.identity(), s3Service::presignGetUrl));
     }
 
+    /**key에 대한 public URL을 생성*/
     private String buildPublicUrl(String key) {
         if (cdnBase != null && !cdnBase.isBlank()) {
             return cdnBase.endsWith("/") ? cdnBase + key : cdnBase + "/" + key;

--- a/frontend/src/features/auction/services/auctions.ts
+++ b/frontend/src/features/auction/services/auctions.ts
@@ -1,5 +1,6 @@
-import { http } from "../../../utils/http";
+//import { http } from "../../../utils/http";
 
+/*
 export interface AuctionCreatePayload {
     productId: number;
     startPrice: number;           // 원화 정수(예: 10000)
@@ -21,4 +22,14 @@ export async function createAuctionEvent(
         userId: opts?.userId ?? null,
         token: opts?.token ?? null,
     });
+}
+*/
+
+// src/features/auction/services/auctions.ts
+import { http } from '../../../utils/http';
+import type { AuctionCreateRequest, AuctionCreateResponse } from '../types/auction';
+
+export async function createAuction(payload: AuctionCreateRequest) {
+    // 쿠키로 인증
+    return http.post<AuctionCreateResponse>('/api/auctions', payload);
 }

--- a/frontend/src/features/auction/types/auction.ts
+++ b/frontend/src/features/auction/types/auction.ts
@@ -1,5 +1,6 @@
 // src/features/auction/types/auction.ts 임시 파일
 
+/*
 export type AuctionCreateRequest = {
     productId: number;
     startPrice: number | string; // 서버 BigDecimal 호환
@@ -13,3 +14,14 @@ export type AuctionCreateRequest = {
 export type AuctionCreateResponse = {
     auctionEventId: number;
 };
+*/
+
+// src/features/auction/types/auction.ts
+export interface AuctionCreateRequest {
+    productId: number;
+    startPrice: number;
+    endAt: string;
+}
+export interface AuctionCreateResponse {
+    id: number;
+}

--- a/frontend/src/features/payment/hooks/useServerPayments.ts
+++ b/frontend/src/features/payment/hooks/useServerPayments.ts
@@ -1,11 +1,64 @@
+// hooks/useServerPayments.ts
 import { useEffect, useState } from 'react';
-import type { FetchPaymentsParams, Payment, ServerPaymentStatus } from '../types/payment';
+import type {
+    FetchPaymentsParams,
+    Payment,
+    PaymentsPageDto,
+    ServerPayment,
+    ServerPaymentStatus,
+} from '../types/payment';
 import { fetchPayments } from '../services/paymentService';
+
+// ---- 매핑 유틸 (간단 버전) ----
+function mapMethodToKo(code: string) {
+    switch (code) {
+        case 'CARD': return '신용카드';
+        case 'KAKAO_PAY': return '카카오페이';
+        case 'TRANSFER': return '계좌이체';
+        default: return code;
+    }
+}
+function mapStatusToUi(s: ServerPaymentStatus): 'completed' | 'cancelled' {
+    return s === 'SUCCESS' ? 'completed' : 'cancelled';
+}
+function toYmd(isoOrYmd?: string | null) {
+    if (!isoOrYmd) return '';
+    const d = new Date(isoOrYmd);
+    if (!Number.isNaN(d.getTime())) {
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${y}-${m}-${day}`;
+    }
+    return isoOrYmd.slice(0, 10);
+}
+function mapServerPayment(p: ServerPayment): Payment {
+    const baseDate = p.confirmedAt || p.requestedAt;
+    return {
+        id: p.paymentId,
+        userId: p.userId,
+        orderId: p.orderId,
+        transactionId: p.transactionId,
+        amount: p.amount,
+        convertedPoint: p.convertedPoint,
+        method: mapMethodToKo(p.paymentMethod),
+        status: mapStatusToUi(p.paymentStatus),
+        date: toYmd(baseDate),
+        requestedAt: p.requestedAt,
+        confirmedAt: p.confirmedAt ?? null,
+    };
+}
+
+// UI 필터값 → 서버 상태값 변환 (그대로 유지)
+export function toServerStatus(ui: 'all' | 'completed' | 'cancelled'): ServerPaymentStatus | 'ALL' {
+    if (ui === 'all') return 'ALL';
+    return ui === 'completed' ? 'SUCCESS' : 'CANCELLED';
+}
 
 export function useServerPayments(initial: FetchPaymentsParams) {
     const [params, setParams] = useState<FetchPaymentsParams>(initial);
-    const [items, setItems] = useState<Payment[]>([]);
-    const [page, setPage] = useState<number>(initial.page ?? 0); // 0-based
+    const [items, setItems] = useState<Payment[]>([]); // 기본값 []
+    const [page, setPage] = useState<number>(initial.page ?? 0);
     const [size, setSize] = useState<number>(initial.size ?? 10);
     const [totalPages, setTotalPages] = useState<number>(1);
     const [totalElements, setTotalElements] = useState<number>(0);
@@ -17,10 +70,11 @@ export function useServerPayments(initial: FetchPaymentsParams) {
         setError(null);
         try {
             const merged = { ...params, ...override, page, size };
-            const res = await fetchPayments(merged);
-            setItems(res.items);
-            setTotalPages(res.totalPages);
-            setTotalElements(res.totalElements);
+            const dto: PaymentsPageDto = await fetchPayments(merged);
+            const mapped = (dto.content ?? []).map(mapServerPayment);
+            setItems(mapped);
+            setTotalPages(dto.totalPages);
+            setTotalElements(dto.totalElements);
         } catch (e) {
             setError(e instanceof Error ? e : new Error('Unknown error'));
         } finally {
@@ -31,17 +85,11 @@ export function useServerPayments(initial: FetchPaymentsParams) {
     useEffect(() => {
         void reload();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [page, size, params.userId, params.status, params.from, params.to, params.sort]);
+    }, [page, size, params.status, params.from, params.to, params.sort]);
 
     return {
         items, loading, error,
         page, size, totalPages, totalElements,
         setPage, setSize, setParams, reload,
     };
-}
-
-// UI 필터값 → 서버 상태값 변환
-export function toServerStatus(ui: 'all' | 'completed' | 'cancelled'): ServerPaymentStatus | 'ALL' {
-    if (ui === 'all') return 'ALL';
-    return ui === 'completed' ? 'SUCCESS' : 'CANCELLED';
 }

--- a/frontend/src/features/payment/pages/PaymentRecordsPage.tsx
+++ b/frontend/src/features/payment/pages/PaymentRecordsPage.tsx
@@ -35,15 +35,11 @@ const PaymentRecordsPage: React.FC = () => {
     const [searchTerm, setSearchTerm] = useState<string>('');
     const [paymentStatus, setPaymentStatus] = useState<PaymentTableFilter>('all');
 
-    // TODO: 실제 로그인 유저의 ID로 교체
-    const userId = 1; //하드코딩 -> 후에 추가
-
     const { from, to } = rangeFor(dateFilter);
 
     const {
         items, loading, error, page, totalPages, setPage, setParams,
     } = useServerPayments({
-        userId,
         page: 0,
         size: 10,
         status: 'ALL',
@@ -56,19 +52,18 @@ const PaymentRecordsPage: React.FC = () => {
     useEffect(() => {
         setParams((p) => ({
             ...p,
-            userId,
             status: toServerStatus(paymentStatus),
             from,
             to,
             sort: 'requestedAt,desc',
         }));
         setPage(0);
-    }, [userId, paymentStatus, from, to, setParams, setPage]);
+    }, [paymentStatus, from, to, setParams, setPage]);
 
     // 검색어는 클라이언트에서 결제수단(method)에만 적용
     const visible = useMemo(
         () =>
-            items.filter((p) =>
+            (items ?? []).filter((p) =>
                 searchTerm.trim()
                     ? p.method.toLowerCase().includes(searchTerm.trim().toLowerCase())
                     : true

--- a/frontend/src/features/payment/services/paymentService.ts
+++ b/frontend/src/features/payment/services/paymentService.ts
@@ -1,3 +1,5 @@
+
+/*
 import type {
     FetchPaymentsParams,
     PaymentsPageDto,
@@ -57,25 +59,23 @@ export async function finalizePortoneCharge(payload: {
     merchantUid: string;
     amount: number;
 }) {
-    const res = await fetch("/api/payments/portone/complete", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+    const res = await fetch('/api/payments/portone/complete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
-        credentials: "include",
+        credentials: 'include',
     });
     if (!res.ok) {
-        const msg = await res.text().catch(() => "");
-        throw new Error(msg || "결제 검증/적립에 실패했습니다.");
+        const msg = await res.text().catch(() => '');
+        throw new Error(msg || '결제 검증/적립에 실패했습니다.');
     }
-    return res.json(); // { addedPoint: number, currentPoint: number, ... } 등
+    return res.json(); // { addedPoint, currentPoint, ... }
 }
 
 export async function fetchPayments(params: FetchPaymentsParams) {
     const search = new URLSearchParams();
 
-    search.set('userId', String(params.userId));
 
-    // 선택
     if (params.page != null) search.set('page', String(params.page)); // 0-based
     if (params.size != null) search.set('size', String(params.size));
     if (params.status && params.status !== 'ALL') search.set('status', params.status);
@@ -86,7 +86,7 @@ export async function fetchPayments(params: FetchPaymentsParams) {
     const res = await fetch(`${BASE_URL}/api/payments/records?${search.toString()}`, {
         method: 'GET',
         headers: { Accept: 'application/json' },
-        credentials: 'include', // 후에 Authorization 헤더 추가
+        credentials: 'include',
     });
 
     if (!res.ok) {
@@ -106,4 +106,22 @@ export async function fetchPayments(params: FetchPaymentsParams) {
         first: json.first,
         last: json.last,
     };
+}
+*/
+
+// services/paymentService.ts
+import { apiFetch } from '../../../utils/apiFetch';
+import type { PaymentsPageDto, FetchPaymentsParams } from '../types/payment';
+
+export async function fetchPayments(params: FetchPaymentsParams) {
+    const qs = new URLSearchParams();
+
+    if (params.page != null) qs.set('page', String(params.page));
+    if (params.size != null) qs.set('size', String(params.size));
+    if (params.status && params.status !== 'ALL') qs.set('status', params.status);
+    if (params.from) qs.set('from', params.from);
+    if (params.to) qs.set('to', params.to);
+    if (params.sort) qs.set('sort', params.sort);
+
+    return apiFetch<PaymentsPageDto>(`/api/payments/records?${qs.toString()}`);
 }

--- a/frontend/src/features/payment/types/payment.ts
+++ b/frontend/src/features/payment/types/payment.ts
@@ -4,7 +4,6 @@ export type ServerPaymentStatus = PaymentStatus;
 
 // 서버 호출 파라미터
 export interface FetchPaymentsParams {
-    userId: number;  // 필수
     page?: number;   // 0-based
     size?: number;
     status?: PaymentStatus | 'ALL';
@@ -56,6 +55,6 @@ export interface Payment {
     confirmedAt?: string | null;
 }
 
-// 필터 타입
+// UI 필터 타입
 export type DateFilter = 'today' | '1week' | '1month' | '3months';
 export type PaymentTableFilter = 'all' | 'completed' | 'cancelled';

--- a/frontend/src/features/product/pages/NewAuctionProductPage.tsx
+++ b/frontend/src/features/product/pages/NewAuctionProductPage.tsx
@@ -1,10 +1,11 @@
+// src/features/product/pages/NewAuctionProductPage.tsx
 import React, { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { presign, uploadToS3 } from "../../upload/services/uploads";
 import { makeSafeFileName } from "../../upload/utils/naming";
 import { createProduct, finalizeImages } from "../services/products";
-import { createAuctionEvent } from "../../auction/services/auctions";
+import { createAuction } from "../../auction/services/auctions";
 
 import type { Brand, Category, Condition, ProductCreatePayload } from "../types/product";
 
@@ -30,8 +31,7 @@ const CATEGORY_OPTIONS: { value: Category; label: string }[] = [
 const BRAND_ALLOW: Brand[] = BRAND_OPTIONS.map((b) => b.value);
 const CATEGORY_ALLOW: Category[] = CATEGORY_OPTIONS.map((c) => c.value);
 
-const TEST_USER_ID = 1 as const;            // 임시 헤더. 추후 JWT 교체 예정
-const DEFAULT_STATUS = "AVAILABLE" as const; // 서버 기본값
+const DEFAULT_STATUS = "AVAILABLE" as const;
 
 /** ---- datetime-local 유틸(로컬 기준 & 10분 스냅) ---- */
 const TEN_MIN_MS = 10 * 60 * 1000;
@@ -98,7 +98,9 @@ const NewAuctionProductPage: React.FC = () => {
             e.currentTarget.value = "";
             return;
         }
-        const valid = picked.every((f) => ["image/jpeg", "image/png", "image/jpg"].includes(f.type || ""));
+        const valid = picked.every((f) =>
+            ["image/jpeg", "image/png", "image/jpg"].includes(f.type || "")
+        );
         if (!valid) {
             alert("JPG/PNG만 업로드 가능합니다.");
             e.currentTarget.value = "";
@@ -113,7 +115,7 @@ const NewAuctionProductPage: React.FC = () => {
             for (const f of picked) {
                 const ct = f.type === "image/png" ? "image/png" : "image/jpeg";
                 const safeName = makeSafeFileName(f.name, ct);
-                const { key, putUrl } = await presign(safeName, ct, { userId: TEST_USER_ID });
+                const { key, putUrl } = await presign(safeName, ct); // 쿠키 인증
                 await uploadToS3(putUrl, f, ct);
                 newFiles.push(f);
                 newPreviews.push(URL.createObjectURL(f));
@@ -181,22 +183,19 @@ const NewAuctionProductPage: React.FC = () => {
                 images,
             };
 
-            const { productId } = await createProduct(payload, { userId: TEST_USER_ID });
+            const { productId } = await createProduct(payload); // 쿠키 인증
 
             // 3) 이미지 finalize
-            await finalizeImages(productId, { userId: TEST_USER_ID });
+            await finalizeImages(productId); // 쿠키 인증
 
             // 4) 경매 자동 생성(시작가 & 종료일 있을 때만)
             try {
                 if (startPrice !== "" && auctionEndAt) {
-                    await createAuctionEvent(
-                        {
-                            productId,
-                            startPrice: Number(startPrice),
-                            endAt: new Date(auctionEndAt).toISOString(), // 로컬 → ISO
-                        },
-                        { userId: TEST_USER_ID }
-                    );
+                    await createAuction({
+                        productId,
+                        startPrice: Number(startPrice),
+                        endAt: new Date(auctionEndAt).toISOString(), // 로컬 → ISO
+                    }); // 쿠키 인증
                 }
             } catch (e) {
                 console.error(e);
@@ -207,7 +206,7 @@ const NewAuctionProductPage: React.FC = () => {
             alert("상품이 등록되었습니다. 경매가 시작됩니다.");
             navigate("/auction", { replace: true });
 
-            //정리
+            // 정리
             previewUrls.forEach((u) => URL.revokeObjectURL(u));
             setSelectedImages([]);
             setPreviewUrls([]);
@@ -262,11 +261,15 @@ const NewAuctionProductPage: React.FC = () => {
                                         ) : (
                                             <label
                                                 className={`h-full flex flex-col items-center justify-center border-2 border-dashed rounded-lg cursor-pointer ${
-                                                    isImageLimitReached ? "border-gray-200 cursor-not-allowed opacity-50" : "border-gray-300 hover:border-blue-500"
+                                                    isImageLimitReached
+                                                        ? "border-gray-200 cursor-not-allowed opacity-50"
+                                                        : "border-gray-300 hover:border-blue-500"
                                                 }`}
                                             >
                                                 <i className="fas fa-plus text-gray-400 mb-2" />
-                                                <span className="text-sm text-gray-500">{index === 0 ? "대표 이미지" : "추가 이미지"}</span>
+                                                <span className="text-sm text-gray-500">
+                          {index === 0 ? "대표 이미지" : "추가 이미지"}
+                        </span>
                                                 <input
                                                     type="file"
                                                     accept="image/jpeg,image/png,image/jpg"
@@ -368,7 +371,7 @@ const NewAuctionProductPage: React.FC = () => {
 
                             {/* 색상 */}
                             <div>
-                                <label className="block text-sm font-medium text-gray-700 mb-1">색상</label>
+                                <label className="block text.sm font-medium text-gray-700 mb-1">색상</label>
                                 <div className="relative">
                                     <select
                                         className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none cursor-pointer"
@@ -428,6 +431,7 @@ const NewAuctionProductPage: React.FC = () => {
                                     </label>
                                 </div>
                             </div>
+
                             {/* 출시일 */}
                             <div>
                                 <label className="block text-sm font-medium text-gray-700 mb-1">출시일(권장)</label>
@@ -436,15 +440,14 @@ const NewAuctionProductPage: React.FC = () => {
                                         type="date"
                                         className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                                         min="1980-01-01"
-                                        max={new Date().toISOString().split("T")[0]}  // 오늘 이전만 선택
+                                        max={new Date().toISOString().split("T")[0]}
                                         value={releaseDate}
-                                        onChange={(e) => setReleaseDate(e.target.value)} // "YYYY-MM-DD"
+                                        onChange={(e) => setReleaseDate(e.target.value)}
                                     />
                                     <i className="fas absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none" />
                                 </div>
                             </div>
                         </div>
-
 
                         {/* 경매 표시용 */}
                         <div className="grid grid-cols-2 gap-6">
@@ -465,7 +468,7 @@ const NewAuctionProductPage: React.FC = () => {
 
                             {/* 경매 종료일 */}
                             <div>
-                                <label className="block text-sm font-medium text-gray-700 mb-1">경매 종료일</label>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">경매 종료일(종료 시간은 10분 단위로 조정합니다.)</label>
                                 <div className="relative">
                                     <input
                                         type="datetime-local"

--- a/frontend/src/features/product/services/products.ts
+++ b/frontend/src/features/product/services/products.ts
@@ -1,3 +1,4 @@
+/*
 import { http } from "../../../utils/http";
 import type {
     ProductCreatePayload,
@@ -25,4 +26,30 @@ export async function finalizeImages(
         {}, // 안전하게 빈 JSON
         { userId: opts?.userId ?? null, token: opts?.token ?? null }
     );
+}
+*/
+
+import { apiFetch } from '../../../utils/apiFetch';
+import type {
+    ProductCreatePayload,
+    CreateProductResponse,
+    FinalizeImagesResponse,
+} from '../types/product';
+
+// 서버 응답이 { id } 또는 { productId } 일 수 있으므로 정규화해서 반환
+export async function createProduct(payload: ProductCreatePayload): Promise<CreateProductResponse> {
+    const res = await apiFetch<{ id?: number; productId?: number }>('/api/products', {
+        method: 'POST',
+        json: payload,
+    });
+    const productId = res.productId ?? res.id;
+    if (!productId) throw new Error('서버 응답에 productId/id가 없습니다.');
+    return { productId };
+}
+
+export async function finalizeImages(productId: number): Promise<FinalizeImagesResponse> {
+    return apiFetch<FinalizeImagesResponse>(`/api/products/${productId}/finalize-images`, {
+        method: 'POST',
+        json: {}, // 빈 JSON 안전하게 전송
+    });
 }

--- a/frontend/src/features/product/types/product.ts
+++ b/frontend/src/features/product/types/product.ts
@@ -1,3 +1,5 @@
+
+/*
 // 서버 enum과 1:1로 맞춘 문자열 유니온
 export type Brand =
     | "NIKE" | "ADIDAS" | "NB" | "CONVERSE" | "VANS" | "PUMA" | "REEBOK" | "ASICS";
@@ -43,4 +45,39 @@ export interface Product {
     category: Category;
     price?: number;
     image?: string;
+}
+*/
+
+// src/features/product/types/product.ts
+export type Brand = "NIKE" | "ADIDAS" | "NB" | "CONVERSE" | "VANS" | "PUMA" | "REEBOK" | "ASICS";
+export type Category = "SNEAKERS" | "RUNNING" | "BASKETBALL" | "CANVAS";
+export type Condition = "NEW" | "USED";
+export type Status = "AVAILABLE" | "SOLD_OUT" | "CANCELLED";
+
+export interface ProductCreatePayload {
+    category: Category;
+    status: Status;
+    condition: Condition;
+    brand: Brand;
+    size: number;
+    name: string;
+    description: string;
+    modelCode: string | null;
+    colorway: string | null;
+    releaseDate: string | null;
+    images: Array<{
+        filePath: string;
+        fileName: string;
+        sortOrder: number;
+        isThumbnail: boolean;
+    }>;
+}
+
+export interface CreateProductResponse {
+    productId: number;
+}
+
+export interface FinalizeImagesResponse {
+    id: number;
+    success: boolean;
 }

--- a/frontend/src/features/profile/api/point.ts
+++ b/frontend/src/features/profile/api/point.ts
@@ -1,12 +1,7 @@
-import { apiFetch } from "../../../utils/apiFetch";
-import type { PointSummaryResponse } from "../types/ProfilePointProps";
+import { apiFetch } from '../../../utils/apiFetch';                       // ← ../../../ (api → profile → features → src)
+import type { ApiResponse } from '../../user/types/AuthTypes';            // ← ../../ (api → profile → user)
+import type { PointSummaryResponse } from '../types/point';
 
-const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "/api";
-
-export async function fetchUserPoint(userId: number): Promise<PointSummaryResponse> {
-    // ApiResponse 스키마가 아닌 순수 DTO를 반환하므로 제네릭은 unknown으로 두고 수동 캐스팅
-    const data = await apiFetch<unknown>(`${BASE_URL}/users/${userId}/points`, {
-        method: "GET",
-    });
-    return data as PointSummaryResponse;
+export async function fetchUserPoint() {
+    return apiFetch<ApiResponse<PointSummaryResponse>>('/api/users/me/points');
 }

--- a/frontend/src/features/profile/types/point.ts
+++ b/frontend/src/features/profile/types/point.ts
@@ -1,0 +1,4 @@
+export interface PointSummaryResponse {
+    currentPoint: number;
+    addedPoint: number;
+}

--- a/frontend/src/features/upload/services/uploads.ts
+++ b/frontend/src/features/upload/services/uploads.ts
@@ -1,3 +1,4 @@
+/*
 import { http } from "../../../utils/http";
 
 export type PresignResponse = {
@@ -33,3 +34,26 @@ export async function uploadToS3(
         throw new Error(msg);
     }
 }
+*/
+
+// src/features/upload/services/uploads.ts
+import { apiFetch } from '../../../utils/apiFetch';
+import type { PresignResponse } from '../types/upload';
+
+export async function presign(fileName: string, contentType?: string | null) {
+    return apiFetch<PresignResponse>('/api/uploads/presign', {
+        method: 'POST',
+        json: { fileName, contentType: contentType ?? null },
+    });
+}
+
+export async function uploadToS3(putUrl: string, file: File | Blob, contentType: string) {
+    const res = await fetch(putUrl, {
+        method: 'PUT',
+        headers: { 'Content-Type': contentType },
+        body: file,
+    });
+    if (!res.ok) throw new Error(`S3 업로드 실패: ${res.status}`);
+}
+
+

--- a/frontend/src/features/upload/types/upload.ts
+++ b/frontend/src/features/upload/types/upload.ts
@@ -1,3 +1,8 @@
+export interface PresignRequest {
+    fileName: string;
+    contentType?: string | null;
+}
+
 export type PresignResponse = {
     key: string;      // products/tmp/xxx.jpg
     putUrl: string;   // S3 presigned PUT URL

--- a/frontend/src/utils/http.ts
+++ b/frontend/src/utils/http.ts
@@ -1,4 +1,5 @@
-// 공용 HTTP 유틸 + 임시 인증 (X-User-Id) -> 나중에 JWT로 교체
+// src/utils/http.ts
+// 공용 HTTP 유틸 — JWT 쿠키 기반으로 통일
 
 export type ErrorResponse = {
     errorCode?: string;
@@ -33,49 +34,41 @@ export function throwHttpError(body: ErrorResponse | null, fallback: string): ne
     throw new Error(msg);
 }
 
-/** 인증 상태: 지금은 X-User-Id, 추후 JWT로 전환 예정 */
+/** 선택용: 필요 시만 Authorization 헤더를 쓰고, 기본은 쿠키로 인증 */
 let AUTH_TOKEN: string | null = null;
-let TEST_USER_ID: number | null = 1;
-
 export function setAuthToken(token: string | null) {
     AUTH_TOKEN = token;
-}
-export function setTestUserId(userId: number | null) {
-    TEST_USER_ID = userId;
-}
-
-function buildAuthHeaders(overrides?: { token?: string; userId?: number }): Record<string, string> {
-    const token = overrides?.token ?? AUTH_TOKEN;
-    if (token) {
-        return { Authorization: `Bearer ${token}` };
-    }
-    const userId = overrides?.userId ?? TEST_USER_ID;
-    return userId ? { "X-User-Id": String(userId) } : {};
 }
 
 type ApiOptions = {
     method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
     headers?: HeadersInit;
+    /** 명시적으로 토큰을 넘길 때만 Authorization 헤더를 추가합니다. */
     token?: string | null;
-    userId?: number | null;
     body?: unknown;
     signal?: AbortSignal;
 };
 
 export async function apiFetch<T>(url: string, opts: ApiOptions = {}): Promise<T> {
-    const { method = "GET", body, headers: extra, token, userId, signal } = opts;
+    const { method = "GET", body, headers: extra, token, signal } = opts;
 
-    // ⚠️ TS2322 방지: object를 먼저 만든 뒤 조건부로 key 설정
-    const baseHeaders: Record<string, string> = {};
+    const baseHeaders: Record<string, string> = {
+        Accept: "application/json",
+    };
     if (typeof body === "object" && body !== null && !(body instanceof FormData)) {
         baseHeaders["Content-Type"] = "application/json";
     }
-    const auth = buildAuthHeaders({ token: token ?? undefined, userId: userId ?? undefined });
-    const headers: HeadersInit = { ...baseHeaders, ...auth, ...(extra ?? {}) };
+    //기본은 쿠키 인증. 토큰이 명시되면 Authorization도 추가.
+    if (token ?? AUTH_TOKEN) {
+        baseHeaders["Authorization"] = `Bearer ${token ?? AUTH_TOKEN}`;
+    }
+
+    const headers: HeadersInit = { ...baseHeaders, ...(extra ?? {}) };
 
     const init: RequestInit = {
         method,
         headers,
+        credentials: "include",
         body:
             typeof body === "string"
                 ? body


### PR DESCRIPTION
### 작업 내용
- 컨트롤러 API에 JWT 기반 인증 적용
  - @RequestHeader("X-User-Id") 제거
  - @AuthenticationPrincipal User authUser 적용
- 상품(Product), 경매(Auction), 결제(Payment) 등 주요 API 수정
- S3 presign, 이미지 finalize 등 인증 방식 통일
- 각 컨트롤러 및 서비스 메서드에 Javadoc 주석 추가

### 변경 이유
- 헤더 기반 인증에서 JWT 기반 인증으로 전환
- API 문서화(Javadoc)를 통해 유지보수성 및 가독성 향상

### 테스트
- JWT 필터 통해 인증된 사용자 요청 정상 동작 확인
- Swagger 및 로컬 테스트로 API 응답 검증

close #197 