### PR TITLE
feat: 경매 상품 상세 조회 api 및 화면 구현, 파일 서빙 기능 추가

### DIFF
--- a/backend/demo/src/main/java/com/sesac/solbid/controller/AuctionQueryController.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/controller/AuctionQueryController.java
@@ -1,0 +1,31 @@
+package com.sesac.solbid.controller;
+
+import com.sesac.solbid.domain.User;
+import com.sesac.solbid.dto.auction.response.AuctionDetailResponse;
+import com.sesac.solbid.service.auction.AuctionQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auctions")
+public class AuctionQueryController {
+
+    private final AuctionQueryService auctionQueryService;
+
+    /**
+     * 상품 상세 조회
+     * */
+    @GetMapping("/{auctionId}")
+    public AuctionDetailResponse getDetail(
+            @PathVariable Long auctionId,
+            @AuthenticationPrincipal User authUser
+    ) {
+        // 지금은 사용하지 않지만, 권한 체크나 viewCount 증가 시에 활용 가능
+        return auctionQueryService.getAuctionDetail(auctionId);
+    }
+}

--- a/backend/demo/src/main/java/com/sesac/solbid/controller/FileController.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/controller/FileController.java
@@ -1,0 +1,104 @@
+package com.sesac.solbid.controller;
+
+import com.sesac.solbid.exception.CustomException;
+import com.sesac.solbid.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.HandlerMapping;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class FileController {
+
+    private final S3Client s3Client;
+
+    @Value("${app.s3.bucket}")
+    private String bucket;
+
+    /**
+     * S3 키를 받아 이미지/파일을 스트리밍 반환
+     *
+     * GET /api/files/products/tmp/202509/example.png
+     *
+     * @param request   {@link HttpServletRequest}.
+     *                  <code>/api/files/</code> 이하 전체 경로를 추출 시 사용
+     * @param authUser  인증된 사용자 객체({@code null}일 수 있음)
+     *                  단순히 로그 기록용으로만 사용
+     * @return          S3 객체를 스트리밍 형태의 {@link Resource}로 담은 {@link ResponseEntity}
+     *                  HTTP 헤더와 콘텐츠 타입이 함께 설정되어 반환
+     */
+    @GetMapping("/api/files/**")
+    public ResponseEntity<Resource> getFile(
+            HttpServletRequest request,
+            @AuthenticationPrincipal User authUser
+    ) {
+        // /api/files/ 이하 전체를 key로 사용
+        String path = (String) request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
+        String rawKey = path.replaceFirst("/api/files/", "");
+        // 브라우저/프록시가 인코딩했을 경우 대비
+        String key = URLDecoder.decode(rawKey, StandardCharsets.UTF_8);
+
+        log.info("Serving S3 file: bucket={}, key={}, by={}",
+                bucket, key, (authUser != null ? authUser.getUsername() : "anonymous"));
+
+        try {
+            GetObjectRequest get = GetObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+
+            // S3 스트림을 반환
+            ResponseInputStream<?> s3Stream = s3Client.getObject(get);
+            Resource resource = new InputStreamResource(s3Stream);
+
+            MediaType mediaType = detectMediaType(key);
+
+            return ResponseEntity.ok()
+                    .contentType(mediaType)
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + fileNameOf(key) + "\"")
+                    // 필요 시 캐시 정책 조정 예정
+                    .cacheControl(CacheControl.noCache())
+                    .body(resource);
+
+        } catch (Exception e) {
+            log.error("S3 file serving error: bucket={}, key={}, msg={}", bucket, key, e.getMessage(), e);
+            throw new CustomException(ErrorCode.S3_IO_ERROR);
+        }
+    }
+
+    private static String fileNameOf(String key) {
+        int idx = key.lastIndexOf('/');
+        return (idx >= 0 ? key.substring(idx + 1) : key);
+    }
+
+    /** 확장자 기반 Content-Type */
+    private static MediaType detectMediaType(String key) {
+        String lower = key.toLowerCase(Locale.ROOT);
+        if (lower.endsWith(".png"))  return MediaType.IMAGE_PNG;
+        if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return MediaType.IMAGE_JPEG;
+        //if (lower.endsWith(".gif"))  return MediaType.IMAGE_GIF;
+        //if (lower.endsWith(".webp")) return MediaType.parseMediaType("image/webp");
+        //if (lower.endsWith(".svg"))  return MediaType.parseMediaType("image/svg+xml");
+        return MediaType.APPLICATION_OCTET_STREAM;
+    }
+}

--- a/backend/demo/src/main/java/com/sesac/solbid/domain/Notification.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/domain/Notification.java
@@ -37,4 +37,7 @@ public class Notification {
 
     private LocalDateTime createAt;
 
+    //기본값/시간 자동화
+    @PrePersist void prePersist(){ if(isRead==null) isRead=false; if(createAt==null) createAt=LocalDateTime.now(); }
+
 }

--- a/backend/demo/src/main/java/com/sesac/solbid/dto/auction/response/AuctionDetailResponse.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/dto/auction/response/AuctionDetailResponse.java
@@ -1,0 +1,46 @@
+package com.sesac.solbid.dto.auction.response;
+
+import com.sesac.solbid.domain.enums.AuctionStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AuctionDetailResponse(
+        // Auction
+        Long auctionEventId,
+        AuctionStatus status,
+        BigDecimal startPrice,
+        BigDecimal buyoutPrice,
+        BigDecimal currentPrice,
+        BigDecimal tickSize,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        Integer extendSeconds,
+        Integer viewCount,
+        Boolean isBlind,
+        long version,
+
+        // Product summary
+        ProductSummary product
+) {
+    public record ProductSummary(
+            Long productId,
+            String name,
+            String brand,       // ENUM 문자열
+            String category,    // ENUM 문자열
+            Integer size,
+            String condition,   // ENUM 문자열
+            String modelCode,
+            String colorway,
+            LocalDate releaseDate,
+            List<ProductImage> images
+    ) {}
+
+    public record ProductImage(
+            String filePath,
+            Boolean isThumbnail,
+            Integer sortOrder
+    ) {}
+}

--- a/backend/demo/src/main/java/com/sesac/solbid/repository/AuctionEventRepository.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/repository/AuctionEventRepository.java
@@ -4,10 +4,29 @@ package com.sesac.solbid.repository;
 import com.sesac.solbid.domain.AuctionEvent;
 import com.sesac.solbid.domain.Product;
 import com.sesac.solbid.domain.enums.AuctionStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Collection;
+import java.util.Optional;
 
 public interface AuctionEventRepository extends JpaRepository<AuctionEvent, Long> {
     boolean existsByProductAndStatusIn(Product product, Collection<AuctionStatus> statuses);
+
+    /**상품 상세 조회*/
+    // 상세 조회용: product까지 즉시 로딩
+    @Query("""
+           select a
+           from AuctionEvent a
+           join fetch a.product p
+           where a.auctionEventId = :id
+           """)
+    Optional<AuctionEvent> findDetail(Long id);
+
+    // (추후 입찰용) 낙관락
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("select a from AuctionEvent a join fetch a.product p where a.auctionEventId = :id")
+    Optional<AuctionEvent> findByIdForUpdateOptimistic(Long id);
 }

--- a/backend/demo/src/main/java/com/sesac/solbid/repository/ProductImageRepository.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/repository/ProductImageRepository.java
@@ -1,7 +1,14 @@
 package com.sesac.solbid.repository;
 
+import com.sesac.solbid.domain.Product;
 import com.sesac.solbid.domain.ProductImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
+
+    /**상품 상세 조회*/
+    List<ProductImage> findByProductOrderBySortOrderAsc(Product product);
+
 }

--- a/backend/demo/src/main/java/com/sesac/solbid/service/auction/AuctionQueryService.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/auction/AuctionQueryService.java
@@ -1,0 +1,8 @@
+package com.sesac.solbid.service.auction;
+
+import com.sesac.solbid.dto.auction.response.AuctionDetailResponse;
+
+public interface AuctionQueryService {
+    /**상품 상세 조회*/
+    AuctionDetailResponse getAuctionDetail(Long auctionId);
+}

--- a/backend/demo/src/main/java/com/sesac/solbid/service/auction/AuctionQueryServiceImpl.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/auction/AuctionQueryServiceImpl.java
@@ -6,6 +6,7 @@ import com.sesac.solbid.domain.ProductImage;
 import com.sesac.solbid.dto.auction.response.AuctionDetailResponse;
 import com.sesac.solbid.repository.AuctionEventRepository;
 import com.sesac.solbid.repository.ProductImageRepository;
+import com.sesac.solbid.service.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,12 +17,12 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class AuctionQueryServiceImpl implements AuctionQueryService{
+public class AuctionQueryServiceImpl implements AuctionQueryService {
 
     private final AuctionEventRepository auctionEventRepository;
     private final ProductImageRepository productImageRepository;
+    private final S3Service s3Service; // Presigned URL
 
-    /**상품 상세 조회*/
     @Override
     public AuctionDetailResponse getAuctionDetail(Long auctionId) {
         AuctionEvent a = auctionEventRepository.findDetail(auctionId)
@@ -57,7 +58,7 @@ public class AuctionQueryServiceImpl implements AuctionQueryService{
                         p.getReleaseDate(),
                         images.stream()
                                 .map(img -> new AuctionDetailResponse.ProductImage(
-                                        img.getFilePath(),
+                                        s3Service.presignGetUrl(img.getFilePath()), //Presigned URL 변환
                                         img.isThumbnail(),
                                         img.getSortOrder()
                                 ))

--- a/backend/demo/src/main/java/com/sesac/solbid/service/auction/AuctionQueryServiceImpl.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/auction/AuctionQueryServiceImpl.java
@@ -1,0 +1,68 @@
+package com.sesac.solbid.service.auction;
+
+import com.sesac.solbid.domain.AuctionEvent;
+import com.sesac.solbid.domain.Product;
+import com.sesac.solbid.domain.ProductImage;
+import com.sesac.solbid.dto.auction.response.AuctionDetailResponse;
+import com.sesac.solbid.repository.AuctionEventRepository;
+import com.sesac.solbid.repository.ProductImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuctionQueryServiceImpl implements AuctionQueryService{
+
+    private final AuctionEventRepository auctionEventRepository;
+    private final ProductImageRepository productImageRepository;
+
+    /**상품 상세 조회*/
+    @Override
+    public AuctionDetailResponse getAuctionDetail(Long auctionId) {
+        AuctionEvent a = auctionEventRepository.findDetail(auctionId)
+                .orElseThrow(() -> new IllegalArgumentException("AUCTION_NOT_FOUND"));
+
+        Product p = a.getProduct();
+        List<ProductImage> images = productImageRepository.findByProductOrderBySortOrderAsc(p);
+
+        BigDecimal current = (a.getHighestBidAmount() == null) ? a.getStartPrice() : a.getHighestBidAmount();
+
+        return new AuctionDetailResponse(
+                a.getAuctionEventId(),
+                a.getStatus(),
+                a.getStartPrice(),
+                a.getBuyoutPrice(),
+                current,
+                a.getTickSize(),
+                a.getStartAt(),
+                a.getEndAt(),
+                a.getExtendSeconds(),
+                a.getViewCount(),
+                a.getIsBlind(),
+                a.getVersion() == null ? 0L : a.getVersion(),
+                new AuctionDetailResponse.ProductSummary(
+                        p.getProductId(),
+                        p.getName(),
+                        p.getProductBrand().name(),
+                        p.getProductCategory().name(),
+                        p.getSize(),
+                        p.getProductCondition().name(),
+                        p.getModelCode(),
+                        p.getColorway(),
+                        p.getReleaseDate(),
+                        images.stream()
+                                .map(img -> new AuctionDetailResponse.ProductImage(
+                                        img.getFilePath(),
+                                        img.isThumbnail(),
+                                        img.getSortOrder()
+                                ))
+                                .toList()
+                )
+        );
+    }
+}

--- a/frontend/src/features/auction/hooks/useAuctionDetail.ts
+++ b/frontend/src/features/auction/hooks/useAuctionDetail.ts
@@ -1,0 +1,40 @@
+import { useEffect, useMemo, useState } from "react";
+import { AuctionsApi } from "../services/auctions";
+import type { AuctionDetailResponse } from "../types/auctionDetail";
+
+export function useAuctionDetail(auctionId?: number) {
+    const validId = useMemo(
+        () => (typeof auctionId === "number" && Number.isFinite(auctionId) ? auctionId : undefined),
+        [auctionId]
+    );
+
+    const [data, setData] = useState<AuctionDetailResponse | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [err, setErr] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!validId) {
+            setErr("유효하지 않은 경매 ID입니다.");
+            setLoading(false);
+            return;
+        }
+        let cancel = false;
+        (async () => {
+            try {
+                setLoading(true);
+                setErr(null);
+                const res = await AuctionsApi.getDetail(validId);
+                if (!cancel) setData(res);
+            } catch (e: unknown) {
+                if (!cancel) setErr(e instanceof Error ? e.message : "불러오기 실패");
+            } finally {
+                if (!cancel) setLoading(false);
+            }
+        })();
+        return () => {
+            cancel = true;
+        };
+    }, [validId]);
+
+    return { data, loading, err };
+}

--- a/frontend/src/features/auction/pages/AuctionDetailPage.tsx
+++ b/frontend/src/features/auction/pages/AuctionDetailPage.tsx
@@ -1,0 +1,371 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
+import { useAuctionDetail } from "../hooks/useAuctionDetail";
+import { toImageUrl } from "../../../utils/toImageUrl";
+
+const krw = (v: number | null | undefined) =>
+    v == null
+        ? "-"
+        : new Intl.NumberFormat("ko-KR", {
+            style: "currency",
+            currency: "KRW",
+            maximumFractionDigits: 0,
+        }).format(v);
+
+const pad2 = (n: number) => String(n).padStart(2, "0");
+
+const diffHMS = (iso: string) => {
+    const now = Date.now();
+    const end = new Date(iso).getTime();
+    const d = Math.max(0, end - now);
+    const s = Math.floor(d / 1000);
+    return {
+        hh: Math.floor(s / 3600),
+        mm: Math.floor((s % 3600) / 60),
+        ss: s % 60,
+        finished: d <= 0,
+    };
+};
+
+const AuctionDetailPage: React.FC = () => {
+    const { auctionId: idStr } = useParams<{ auctionId: string }>();
+    const auctionId = useMemo(() => (idStr ? Number(idStr) : undefined), [idStr]);
+
+    const { data, loading, err } = useAuctionDetail(auctionId);
+
+    const [activeTab, setActiveTab] = useState<"info" | "bids" | "shipping">(
+        "info"
+    );
+    const [showBidModal, setShowBidModal] = useState(false);
+    const [bidAmount, setBidAmount] = useState<string>("");
+
+    // 여러 이미지 배열 지원
+    const images = useMemo(() => data?.product.images ?? [], [data?.product.images]);
+    const [currentImageIndex, setCurrentImageIndex] = useState(0);
+
+    useEffect(() => {
+        if (!images.length) return;
+        const thumbIdx = images.findIndex((i) => i.isThumbnail);
+        setCurrentImageIndex(thumbIdx >= 0 ? thumbIdx : 0);
+    }, [images]);
+
+    const [clock, setClock] = useState({
+        hh: 0,
+        mm: 0,
+        ss: 0,
+        finished: false,
+    });
+
+    useEffect(() => {
+        if (!data?.endAt) return;
+        const tick = () => setClock(diffHMS(data.endAt));
+        tick();
+        const id = window.setInterval(tick, 1000);
+        return () => window.clearInterval(id);
+    }, [data?.endAt]);
+
+    const currentImageSrc = toImageUrl(images[currentImageIndex]?.filePath);
+
+    const handleBidSubmit: React.FormEventHandler = (e) => {
+        e.preventDefault();
+        // TODO: POST /api/auctions/{id}/bids
+        setShowBidModal(false);
+        setBidAmount("");
+    };
+
+    if (loading)
+        return (
+            <div className="min-h-screen flex items-center justify-center">
+                불러오는 중…
+            </div>
+        );
+    if (err || !data)
+        return (
+            <div className="min-h-screen flex items-center justify-center text-red-600">
+                {err ?? "데이터가 없습니다."}
+            </div>
+        );
+
+    return (
+        <div className="min-h-screen bg-gray-50">
+            {/* Breadcrumb */}
+            <div className="max-w-[1440px] mx-auto px-6 py-4">
+                <div className="flex items-center space-x-2 text-sm text-gray-500">
+                    <a href="/" className="hover:text-gray-700 cursor-pointer">
+                        홈
+                    </a>
+                    <i className="fas fa-chevron-right text-xs" />
+                    <a href="#" className="hover:text-gray-700 cursor-pointer">
+                        {data.product.category}
+                    </a>
+                    <i className="fas fa-chevron-right text-xs" />
+                    <span className="text-gray-900">{data.product.name}</span>
+                </div>
+            </div>
+
+            {/* Product Detail */}
+            <div className="max-w-[1440px] mx-auto px-6 pb-12">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-12">
+                    {/* Product Images */}
+                    <div className="space-y-4">
+                        <div className="aspect-square bg-white rounded-lg overflow-hidden flex items-center justify-center">
+                            {currentImageSrc ? (
+                                <img
+                                    src={currentImageSrc}
+                                    alt={data.product.name}
+                                    className="w-full h-full object-cover object-top"
+                                />
+                            ) : (
+                                <div className="text-gray-400">이미지가 없습니다</div>
+                            )}
+                        </div>
+                        {images.length > 1 && (
+                            <div className="grid grid-cols-4 gap-2">
+                                {images.map((img, idx) => {
+                                    const thumb = toImageUrl(img.filePath)!;
+                                    return (
+                                        <button
+                                            key={`${img.filePath}-${idx}`}
+                                            onClick={() => setCurrentImageIndex(idx)}
+                                            className={`aspect-square bg-white rounded-lg overflow-hidden border-2 cursor-pointer ${
+                                                currentImageIndex === idx
+                                                    ? "border-blue-500"
+                                                    : "border-gray-200"
+                                            }`}
+                                        >
+                                            <img
+                                                src={thumb}
+                                                alt={`Product ${idx + 1}`}
+                                                className="w-full h-full object-cover object-top"
+                                            />
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        )}
+                    </div>
+
+                    {/* Product Info */}
+                    <div className="space-y-6">
+                        <div>
+                            <h1 className="text-3xl font-bold text-gray-900">
+                                {data.product.name}
+                            </h1>
+                            <p className="text-lg text-gray-600 mt-2">
+                                {data.product.brand} · {data.product.colorway ?? "-"} ·{" "}
+                                {data.product.size}mm
+                            </p>
+                        </div>
+
+                        {/* 가격 & 상태 */}
+                        <div className="bg-white p-6 rounded-lg shadow-sm">
+                            <div className="flex items-center justify-between mb-4">
+                                <div>
+                                    <div className="mb-3">
+                                        <p className="text-sm text-gray-500">시작가</p>
+                                        <p className="text-xl font-semibold text-gray-600">
+                                            {krw(data.startPrice)}
+                                        </p>
+                                    </div>
+                                    <div>
+                                        <p className="text-sm text-gray-500">현재 입찰가</p>
+                                        <p className="text-3xl font-bold text-blue-600">
+                                            {krw(data.currentPrice)}
+                                        </p>
+                                    </div>
+                                </div>
+                                <div className="text-right">
+                                    <p className="text-sm text-gray-500">상태</p>
+                                    <p className="text-xl font-semibold text-gray-900">
+                                        {data.status}
+                                    </p>
+                                </div>
+                            </div>
+
+                            {/* 남은 시간 */}
+                            <div className="mb-6">
+                                <p className="text-sm text-gray-500 mb-1">남은 시간</p>
+                                {clock.finished ? (
+                                    <div className="text-red-600 font-semibold">경매 종료</div>
+                                ) : (
+                                    <div className="flex items-center space-x-2">
+                                        <TimerBox value={clock.hh} />
+                                        <span className="text-gray-400">:</span>
+                                        <TimerBox value={clock.mm} />
+                                        <span className="text-gray-400">:</span>
+                                        <TimerBox value={clock.ss} />
+                                    </div>
+                                )}
+                            </div>
+
+                            {/* 입찰 버튼 */}
+                            <button
+                                disabled={data.status !== "LIVE" || clock.finished}
+                                onClick={() => setShowBidModal(true)}
+                                className={`w-full py-4 text-white text-lg font-semibold !rounded-button cursor-pointer whitespace-nowrap ${
+                                    data.status !== "LIVE" || clock.finished
+                                        ? "bg-gray-300"
+                                        : "bg-blue-500 hover:bg-blue-600"
+                                }`}
+                            >
+                                {data.status === "LIVE" && !clock.finished
+                                    ? "입찰하기"
+                                    : "입찰 불가"}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Tabs */}
+                <div className="mt-12">
+                    <div className="border-b border-gray-200">
+                        <nav className="flex space-x-8">
+                            <button
+                                onClick={() => setActiveTab("info")}
+                                className={`py-4 px-1 border-b-2 font-medium text-sm cursor-pointer ${
+                                    activeTab === "info" ? "border-blue-500 text-blue-600" : "border-transparent text-gray-500 hover:text-gray-700"
+                                }`}
+                            >
+                                상품정보
+                            </button>
+                            <button
+                                onClick={() => setActiveTab("bids")}
+                                className={`py-4 px-1 border-b-2 font-medium text-sm cursor-pointer ${
+                                    activeTab === "bids" ? "border-blue-500 text-blue-600" : "border-transparent text-gray-500 hover:text-gray-700"
+                                }`}
+                            >
+                                입찰내역
+                            </button>
+                            <button
+                                onClick={() => setActiveTab("shipping")}
+                                className={`py-4 px-1 border-b-2 font-medium text-sm cursor-pointer ${
+                                    activeTab === "shipping" ? "border-blue-500 text-blue-600" : "border-transparent text-gray-500 hover:text-gray-700"
+                                }`}
+                            >
+                                배송/반품 안내
+                            </button>
+                        </nav>
+                    </div>
+
+                    <div className="py-8">
+                        {activeTab === "info" && (
+                            <div className="bg-white p-6 rounded-lg shadow-sm">
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                                    <InfoRow title="브랜드" value={data.product.brand} />
+                                    <InfoRow title="카테고리" value={data.product.category} />
+                                    <InfoRow title="모델 코드" value={data.product.modelCode ?? "-"} />
+                                    <InfoRow title="색상" value={data.product.colorway ?? "-"} />
+                                    <InfoRow title="사이즈" value={`${data.product.size}mm`} />
+                                    <InfoRow title="컨디션" value={data.product.condition} />
+                                    <InfoRow title="출시일" value={data.product.releaseDate ?? "-"} />
+                                    <InfoRow title="호가 단위" value={krw(data.tickSize)} />
+                                    <InfoRow title="즉시구매가" value={krw(data.buyoutPrice)} />
+                                </div>
+                            </div>
+                        )}
+
+                        {activeTab === "bids" && (
+                            <div className="bg-white rounded-lg shadow-sm overflow-hidden">
+                                <div className="px-6 py-4 border-b border-gray-200">
+                                    <h4 className="text-lg font-semibold text-gray-900">입찰 내역</h4>
+                                </div>
+                                <div className="px-6 py-10 text-center text-gray-500">
+                                    SSE 연동 후 표시됩니다.
+                                </div>
+                            </div>
+                        )}
+
+                        {activeTab === "shipping" && (
+                            <div className="bg-white p-6 rounded-lg shadow-sm text-gray-600 space-y-6">
+                                <Section title="배송 안내">
+                                    <ul className="space-y-1">
+                                        <li>• 경매 종료 후 결제 완료 시 1-2일 내 발송</li>
+                                        <li>• 전국 무료배송 (제주/도서산간 제외)</li>
+                                        <li>• 택배사: CJ대한통운</li>
+                                    </ul>
+                                </Section>
+                                <Section title="반품/교환 안내">
+                                    <ul className="space-y-1">
+                                        <li>• 수령 후 7일 이내 반품 신청 가능</li>
+                                        <li>• 단순 변심 반품 시 배송비 고객 부담</li>
+                                        <li>• 상품 하자 시 무료 반품/교환</li>
+                                    </ul>
+                                </Section>
+                            </div>
+                        )}
+                    </div>
+                </div>
+            </div>
+
+            {/* Bid Modal (POST는 다음 스텝에서 붙임) */}
+            {showBidModal && (
+                <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+                    <div className="bg-white rounded-lg p-8 w-full max-w-md relative">
+                        <button
+                            onClick={() => setShowBidModal(false)}
+                            className="absolute top-4 right-4 text-gray-500 hover:text-gray-700 cursor-pointer"
+                            aria-label="닫기"
+                        >
+                            <i className="fas fa-times" />
+                        </button>
+                        <h2 className="text-2xl font-bold text-gray-900 mb-6">입찰하기</h2>
+                        <div className="mb-6">
+                            <p className="text-sm text-gray-500">현재 최고가</p>
+                            <p className="text-2xl font-bold text-blue-600">{krw(data.currentPrice)}</p>
+                            <p className="text-xs text-gray-500 mt-1">최소 입찰 단위: {krw(data.tickSize)}</p>
+                        </div>
+                        <form onSubmit={handleBidSubmit} className="space-y-4">
+                            <div>
+                                <label htmlFor="bidAmount" className="block text-sm font-medium text-gray-700 mb-1">입찰가</label>
+                                <input
+                                    type="number"
+                                    id="bidAmount"
+                                    value={bidAmount}
+                                    onChange={(e) => setBidAmount(e.target.value)}
+                                    min={data.currentPrice + data.tickSize}
+                                    step={data.tickSize}
+                                    placeholder={String(Math.ceil((data.currentPrice + data.tickSize) / 10) * 10)}
+                                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-lg
+                            [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                                    required
+                                />
+                                <p className="text-xs text-gray-500 mt-1">최소 입찰가: {krw(data.currentPrice + data.tickSize)}</p>
+                            </div>
+                            <button type="submit" className="w-full py-3 bg-blue-500 text-white text-lg font-semibold !rounded-button hover:bg-blue-600">
+                                입찰하기
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+const TimerBox: React.FC<{ value: number }> = ({ value }) => (
+    <div className="bg-red-500 text-white px-3 py-1 rounded text-lg font-mono">
+        {pad2(value)}
+    </div>
+);
+
+const InfoRow: React.FC<{ title: string; value: string }> = ({
+                                                                 title,
+                                                                 value,
+                                                             }) => (
+    <div className="flex justify-between">
+        <span className="text-gray-600">{title}</span>
+        <span className="text-gray-900">{value}</span>
+    </div>
+);
+
+const Section: React.FC<{ title: string; children: React.ReactNode }> = ({
+                                                                             title,
+                                                                             children,
+                                                                         }) => (
+    <div>
+        <h4 className="text-lg font-semibold text-gray-900 mb-4">{title}</h4>
+        {children}
+    </div>
+);
+
+export default AuctionDetailPage;

--- a/frontend/src/features/auction/services/auctions.ts
+++ b/frontend/src/features/auction/services/auctions.ts
@@ -1,35 +1,15 @@
-//import { http } from "../../../utils/http";
-
-/*
-export interface AuctionCreatePayload {
-    productId: number;
-    startPrice: number;           // 원화 정수(예: 10000)
-    endAt: string;                // ISO string (예: 2025-09-20T04:30:00.000Z)
-    buyoutPrice?: number | null;  //
-    tickSize?: number | null;     // 기본 1.00
-    extendSeconds?: number | null;// 기본 30
-}
-
-export interface AuctionCreateResponse {
-    auctionEventId: number;
-}
-
-export async function createAuctionEvent(
-    payload: AuctionCreatePayload,
-    opts?: { userId?: number; token?: string | null }
-): Promise<AuctionCreateResponse> {
-    return http.post<AuctionCreateResponse>("/api/auctions", payload, {
-        userId: opts?.userId ?? null,
-        token: opts?.token ?? null,
-    });
-}
-*/
-
-// src/features/auction/services/auctions.ts
 import { http } from '../../../utils/http';
+import type { AuctionDetailResponse } from "../types/auctionDetail";
 import type { AuctionCreateRequest, AuctionCreateResponse } from '../types/auction';
+import { apiFetch } from "../../../utils/http";
+
 
 export async function createAuction(payload: AuctionCreateRequest) {
-    // 쿠키로 인증
     return http.post<AuctionCreateResponse>('/api/auctions', payload);
 }
+
+export const AuctionsApi = {
+    getDetail(auctionId: number) {
+        return apiFetch<AuctionDetailResponse>(`/api/auctions/${auctionId}`);
+    },
+};

--- a/frontend/src/features/auction/types/auctionDetail.ts
+++ b/frontend/src/features/auction/types/auctionDetail.ts
@@ -1,0 +1,32 @@
+export type AuctionStatus = "READY" | "LIVE" | "ENDED" | "SETTLED" | "CANCELED";
+
+export interface AuctionDetailResponse {
+    auctionEventId: number;
+    status: AuctionStatus;
+    startPrice: number;
+    buyoutPrice: number | null;
+    currentPrice: number;
+    tickSize: number;
+    startAt: string;    // "2025-09-17T14:56:29.5646"
+    endAt: string;      // "2025-09-20T06:00:00"
+    extendSeconds: number | null;
+    viewCount: number;
+    isBlind: boolean;
+    version: number;
+    product: {
+        productId: number;
+        name: string;
+        brand: string;
+        category: string;
+        size: number;
+        condition: string;
+        modelCode: string | null;
+        colorway: string | null;
+        releaseDate: string; // YYYY-MM-DD
+        images: Array<{
+            filePath: string;
+            isThumbnail: boolean;
+            sortOrder: number;
+        }>;
+    };
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, createRoutesFromElements, Route } from 'react-router-dom';
 
 import AuctionPage from './features/auction/pages/AuctionPage';
+import AuctionDetailPage from './features/auction/pages/AuctionDetailPage';
 import CartPage from './features/cart/pages/CartPage';
 import CategoryPage from './features/category/pages/CategoryPage';
 import MainPage from './features/main/pages/MainPage';
@@ -42,6 +43,7 @@ const router = createBrowserRouter(
             <Route path="/auth/callback/:provider" element={<OAuth2Callback />} />
             <Route path="/nickname-setup" element={<NicknameSetup />} />
             <Route path="/auction" element={<AuctionPage />} />
+            <Route path="/auction/:auctionId" element={<AuctionDetailPage />} />
             <Route path="/category/:categoryName" element={<CategoryPage />} />
             <Route path="/profile" element={<ProtectedRoute><ProfilePage /></ProtectedRoute>} />
             <Route path="/order" element={<ProtectedRoute><OrderPage /></ProtectedRoute>} />

--- a/frontend/src/utils/toImageUrl.ts
+++ b/frontend/src/utils/toImageUrl.ts
@@ -1,0 +1,13 @@
+/**
+ * 파일 경로를 실제 이미지 URL로 변환
+ * - http/https로 시작하면 그대로 반환
+ * - S3 key면 /api/files/{key} 프록시 경유
+ */
+// src/utils/toImageUrl.ts
+export const toImageUrl = (filePath?: string) =>
+    !filePath
+        ? undefined
+        : filePath.startsWith("http")
+            ? filePath
+            // encodeURIComponent → encodeURI 로 바꿔야 함
+            : `/api/files/${encodeURI(filePath)}`;


### PR DESCRIPTION
##작업 내용

- AuctionDetailPage 구현 및 API 연동
- src/utils/toImageUrl.ts 추가 (공통 이미지 경로 유틸)
- 라우터에 경매 상세 페이지 경로 등록
- FileController 추가하여 S3 이미지 서빙 처리

##TODO 

- 상품 목록 화면에서 특정 상품 클릭 시 상세 페이지로 이동할 수 있도록 연결 기능 추가 예정

close #294 