### PR TITLE
feat(profile): 프로필 상단 영역에 사용자 온도 표시 기능 추가

### DIFF
--- a/backend/demo/src/main/java/com/sesac/solbid/controller/UserController.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/controller/UserController.java
@@ -169,6 +169,7 @@ public class UserController {
             data.put("email", user.getEmail());
             data.put("nickname", user.getNickname());
             data.put("userType", user.getUserType() != null ? user.getUserType().name() : null);
+            data.put("temperature", user.getTemperature());
             // 연결된 소셜 제공자 정보 포함 (있을 경우)
             socialLoginRepository.findByUser(user).ifPresent(sl -> data.put("socialProvider", sl.getProvider().name()));
             return ResponseEntity.ok(ApiResponse.success(data));
@@ -270,6 +271,7 @@ public class UserController {
             data.put("email", user.getEmail());
             data.put("nickname", user.getNickname());
             data.put("userType", user.getUserType() != null ? user.getUserType().name() : null);
+            data.put("temperature", user.getTemperature());
             return ResponseEntity.ok(ApiResponse.success(data, "계정이 재활성화되었습니다."));
         } catch (Exception e) {
             log.error("계정 재활성화 처리 중 예외", e);

--- a/backend/demo/src/test/java/com/sesac/solbid/integration/ApiContractVerificationTest.java
+++ b/backend/demo/src/test/java/com/sesac/solbid/integration/ApiContractVerificationTest.java
@@ -250,7 +250,8 @@ class ApiContractVerificationTest {
                 .andExpect(jsonPath("$.data.userId").exists())
                 .andExpect(jsonPath("$.data.email").value("test@example.com"))
                 .andExpect(jsonPath("$.data.nickname").value("testuser"))
-                .andExpect(jsonPath("$.data.userType").value("USER"));
+                .andExpect(jsonPath("$.data.userType").value("USER"))
+                .andExpect(jsonPath("$.data.temperature").exists());
     }
 
     @Test

--- a/backend/demo/src/test/java/com/sesac/solbid/integration/CompleteApiContractIntegrationTest.java
+++ b/backend/demo/src/test/java/com/sesac/solbid/integration/CompleteApiContractIntegrationTest.java
@@ -399,7 +399,8 @@ class CompleteApiContractIntegrationTest {
                 .andExpect(jsonPath("$.data.userId").exists())
                 .andExpect(jsonPath("$.data.email").value("test@example.com"))
                 .andExpect(jsonPath("$.data.nickname").value("testuser"))
-                .andExpect(jsonPath("$.data.userType").value("USER"));
+                .andExpect(jsonPath("$.data.userType").value("USER"))
+                .andExpect(jsonPath("$.data.temperature").exists());
     }
 
     @Test

--- a/frontend/src/features/profile/api/profile.ts
+++ b/frontend/src/features/profile/api/profile.ts
@@ -1,0 +1,39 @@
+import { apiFetch } from '../../../utils/apiFetch';
+import type { ApiResponse, UserProfile } from '../../user/types/AuthTypes';
+
+/**
+ * 사용자 프로필 정보를 가져오는 API 함수
+ * 온도 정보를 포함한 완전한 사용자 프로필을 반환
+ */
+export const fetchUserProfile = async (): Promise<UserProfile> => {
+  try {
+    const response = await apiFetch<ApiResponse<UserProfile>>('/api/users/me');
+    
+    if (!response.success || !response.data) {
+      throw new Error('사용자 프로필 정보를 찾을 수 없습니다.');
+    }
+    
+    // 온도 정보가 없는 경우 기본값 설정
+    const profile = response.data;
+    if (typeof profile.temperature !== 'number') {
+      profile.temperature = 36.5;
+    }
+    
+    return profile;
+  } catch (error) {
+    // 네트워크 오류나 서버 오류 시 적절한 에러 메시지 제공
+    if (error instanceof Error) {
+      if (error.message.indexOf('HTTP 401') !== -1) {
+        throw new Error('로그인이 필요합니다.');
+      } else if (error.message.indexOf('HTTP 403') !== -1) {
+        throw new Error('접근 권한이 없습니다.');
+      } else if (error.message.indexOf('HTTP 404') !== -1) {
+        throw new Error('사용자 정보를 찾을 수 없습니다.');
+      } else if (error.message.indexOf('HTTP 500') !== -1) {
+        throw new Error('서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
+      throw error;
+    }
+    throw new Error('온도 정보를 불러올 수 없습니다.');
+  }
+};

--- a/frontend/src/features/profile/components/ProfileStats.tsx
+++ b/frontend/src/features/profile/components/ProfileStats.tsx
@@ -1,18 +1,81 @@
-import { statsData, type LegacyProfileStatProps } from "./mockData";
-
-const StatCard = ({ label, value, color }: LegacyProfileStatProps) => (
-    <div className="bg-white rounded-lg shadow-sm p-6 text-center">
-        <div className={`text-2xl font-bold ${color} mb-1`}>{value}</div>
-        <div className="text-gray-600 text-sm">{label}</div>
-    </div>
-);
+import { useState, useEffect } from 'react';
+import TemperatureCard from './TemperatureCard';
+import type { UserProfile } from '../../user/types/AuthTypes';
 
 const ProfileStats = () => {
+    const [temperature, setTemperature] = useState<number>(36.5); // 기본값
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchUserProfile = async () => {
+            try {
+                setLoading(true);
+                setError(null);
+                
+                const response = await fetch('/api/users/me', {
+                    credentials: 'include' // 쿠키 포함
+                });
+                
+                if (!response.ok) {
+                    throw new Error('사용자 정보를 불러올 수 없습니다.');
+                }
+                
+                const result = await response.json();
+                
+                if (result.success && result.data) {
+                    const profile = result.data as UserProfile;
+                    setTemperature(profile.temperature || 36.5);
+                } else {
+                    throw new Error('사용자 온도 정보를 찾을 수 없습니다.');
+                }
+            } catch (err) {
+                console.error('Failed to fetch user profile:', err);
+                setError(err instanceof Error ? err.message : '온도 정보를 불러올 수 없습니다.');
+                // 에러 발생 시 기본값 유지
+                setTemperature(36.5);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchUserProfile();
+    }, []);
+
+    if (loading) {
+        return (
+            <div className="mb-6">
+                <div className="bg-white rounded-lg shadow-sm p-6 text-center">
+                    <div className="flex items-center justify-center mb-2">
+                        <i className="fas fa-spinner fa-spin text-orange-500 text-2xl mr-2" aria-hidden="true"></i>
+                        <div className="text-2xl font-bold text-gray-400">--.-°C</div>
+                    </div>
+                    <div className="text-gray-600 text-sm">온도 정보 로딩 중...</div>
+                </div>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="mb-6">
+                <div className="bg-white rounded-lg shadow-sm p-6 text-center">
+                    <div className="flex items-center justify-center mb-2">
+                        <i className="fas fa-thermometer-half text-orange-500 text-2xl mr-2" aria-hidden="true"></i>
+                        <div className="text-2xl font-bold text-orange-600">
+                            {temperature.toFixed(1)}°C
+                        </div>
+                    </div>
+                    <div className="text-gray-600 text-sm">사용자 온도 (기본값)</div>
+                    <div className="text-red-500 text-xs mt-1">{error}</div>
+                </div>
+            </div>
+        );
+    }
+
     return (
-        <div className="grid grid-cols-2 gap-4 mb-6">
-            {statsData.map((stat) => (
-                <StatCard key={stat.label} {...stat} />
-            ))}
+        <div className="mb-6">
+            <TemperatureCard temperature={temperature} />
         </div>
     );
 };

--- a/frontend/src/features/profile/components/ProfileStats.tsx
+++ b/frontend/src/features/profile/components/ProfileStats.tsx
@@ -1,54 +1,58 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import TemperatureCard from './TemperatureCard';
-import type { UserProfile } from '../../user/types/AuthTypes';
+import { fetchUserProfile } from '../api/profile';
 
 const ProfileStats = () => {
     const [temperature, setTemperature] = useState<number>(36.5); // 기본값
     const [loading, setLoading] = useState<boolean>(true);
     const [error, setError] = useState<string | null>(null);
+    const [retryCount, setRetryCount] = useState<number>(0);
+
+    const loadUserProfile = useCallback(async () => {
+        try {
+            setLoading(true);
+            setError(null);
+            
+            const profile = await fetchUserProfile();
+            setTemperature(profile.temperature);
+            setRetryCount(0); // 성공 시 재시도 카운트 리셋
+        } catch (err) {
+            console.error('Failed to fetch user profile:', err);
+            const errorMessage = err instanceof Error ? err.message : '온도 정보를 불러올 수 없습니다.';
+            setError(errorMessage);
+            
+            // 에러 발생 시 기본값 유지
+            setTemperature(36.5);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    const handleRetry = useCallback(() => {
+        if (retryCount < 3) { // 최대 3회까지 재시도
+            setRetryCount(prev => prev + 1);
+            loadUserProfile();
+        }
+    }, [retryCount, loadUserProfile]);
 
     useEffect(() => {
-        const fetchUserProfile = async () => {
-            try {
-                setLoading(true);
-                setError(null);
-                
-                const response = await fetch('/api/users/me', {
-                    credentials: 'include' // 쿠키 포함
-                });
-                
-                if (!response.ok) {
-                    throw new Error('사용자 정보를 불러올 수 없습니다.');
-                }
-                
-                const result = await response.json();
-                
-                if (result.success && result.data) {
-                    const profile = result.data as UserProfile;
-                    setTemperature(profile.temperature || 36.5);
-                } else {
-                    throw new Error('사용자 온도 정보를 찾을 수 없습니다.');
-                }
-            } catch (err) {
-                console.error('Failed to fetch user profile:', err);
-                setError(err instanceof Error ? err.message : '온도 정보를 불러올 수 없습니다.');
-                // 에러 발생 시 기본값 유지
-                setTemperature(36.5);
-            } finally {
-                setLoading(false);
-            }
-        };
-
-        fetchUserProfile();
-    }, []);
+        loadUserProfile();
+    }, [loadUserProfile]);
 
     if (loading) {
         return (
             <div className="mb-6">
                 <div className="bg-white rounded-lg shadow-sm p-6 text-center">
                     <div className="flex items-center justify-center mb-2">
-                        <i className="fas fa-spinner fa-spin text-orange-500 text-2xl mr-2" aria-hidden="true"></i>
-                        <div className="text-2xl font-bold text-gray-400">--.-°C</div>
+                        <i 
+                            className="fas fa-spinner fa-spin text-orange-500 text-2xl mr-2" 
+                            aria-hidden="true"
+                            role="img"
+                            aria-label="로딩 중"
+                        ></i>
+                        <div className="text-2xl font-bold text-gray-400" aria-live="polite">
+                            --.-°C
+                        </div>
                     </div>
                     <div className="text-gray-600 text-sm">온도 정보 로딩 중...</div>
                 </div>
@@ -61,20 +65,36 @@ const ProfileStats = () => {
             <div className="mb-6">
                 <div className="bg-white rounded-lg shadow-sm p-6 text-center">
                     <div className="flex items-center justify-center mb-2">
-                        <i className="fas fa-thermometer-half text-orange-500 text-2xl mr-2" aria-hidden="true"></i>
+                        <i 
+                            className="fas fa-thermometer-half text-orange-500 text-2xl mr-2" 
+                            aria-hidden="true"
+                            role="img"
+                            aria-label="온도계"
+                        ></i>
                         <div className="text-2xl font-bold text-orange-600">
                             {temperature.toFixed(1)}°C
                         </div>
                     </div>
                     <div className="text-gray-600 text-sm">사용자 온도 (기본값)</div>
-                    <div className="text-red-500 text-xs mt-1">{error}</div>
+                    <div className="text-red-500 text-xs mt-2" role="alert">
+                        {error}
+                    </div>
+                    {retryCount < 3 && (
+                        <button
+                            onClick={handleRetry}
+                            className="mt-2 px-3 py-1 text-xs bg-orange-500 text-white rounded hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 transition-colors"
+                            aria-label="온도 정보 다시 불러오기"
+                        >
+                            다시 시도 ({retryCount}/3)
+                        </button>
+                    )}
                 </div>
             </div>
         );
     }
 
     return (
-        <div className="mb-6">
+        <div className="mb-6" role="region" aria-label="사용자 온도 정보">
             <TemperatureCard temperature={temperature} />
         </div>
     );

--- a/frontend/src/features/profile/components/ProfileStats.tsx
+++ b/frontend/src/features/profile/components/ProfileStats.tsx
@@ -1,7 +1,6 @@
-import type { ProfileStatProps } from "../types/ProfileStatProps";
-import { statsData } from "./mockData";
+import { statsData, type LegacyProfileStatProps } from "./mockData";
 
-const StatCard = ({ label, value, color }: ProfileStatProps) => (
+const StatCard = ({ label, value, color }: LegacyProfileStatProps) => (
     <div className="bg-white rounded-lg shadow-sm p-6 text-center">
         <div className={`text-2xl font-bold ${color} mb-1`}>{value}</div>
         <div className="text-gray-600 text-sm">{label}</div>

--- a/frontend/src/features/profile/components/TemperatureCard.tsx
+++ b/frontend/src/features/profile/components/TemperatureCard.tsx
@@ -1,0 +1,25 @@
+import type { TemperatureCardProps } from "../types/TemperatureCardProps";
+
+const TemperatureCard = ({ temperature }: TemperatureCardProps) => {
+    return (
+        <div className="bg-white rounded-lg shadow-sm p-6 text-center">
+            <div className="flex items-center justify-center mb-2">
+                <i 
+                    className="fas fa-thermometer-half text-orange-500 text-2xl mr-2" 
+                    aria-hidden="true"
+                    role="img"
+                    aria-label="온도계"
+                ></i>
+                <div 
+                    className="text-2xl font-bold text-orange-600"
+                    aria-label={`사용자 온도 ${temperature.toFixed(1)}도`}
+                >
+                    {temperature.toFixed(1)}°C
+                </div>
+            </div>
+            <div className="text-gray-600 text-sm">사용자 온도</div>
+        </div>
+    );
+};
+
+export default TemperatureCard;

--- a/frontend/src/features/profile/components/index.ts
+++ b/frontend/src/features/profile/components/index.ts
@@ -5,3 +5,4 @@ export { default as ProfilePoint } from './ProfilePoint';
 export { default as ProfileStats } from './ProfileStats';
 export { default as ProfileTransaction } from './ProfileTransaction';
 export { default as ProfileAccount } from './ProfileAccount';
+export { default as TemperatureCard } from './TemperatureCard';

--- a/frontend/src/features/profile/components/mockData.ts
+++ b/frontend/src/features/profile/components/mockData.ts
@@ -13,18 +13,6 @@ export const bidData: ProfileBidProps[] = [
     { id: 3, name: "스마트폰 케이스", date: "2024.01.10", price: "15,000원", imageUrl: "https://readdy.ai/api/search-image?query=modern%20smartphone%20case%20clear%20transparent%20design%20clean%20white%20background%20product%20photography%20professional%20lighting%20high%20quality&width=60&height=60&seq=product003&orientation=squarish" },
 ];
 
-// 레거시 통계 데이터 - 추후 작업에서 온도 데이터로 교체될 예정
-export interface LegacyProfileStatProps {
-    label: string;
-    value: string | number;
-    color: string;
-}
-
-export const statsData: LegacyProfileStatProps[] = [
-    { label: "총 주문", value: 12, color: "text-blue-600" },
-    { label: "적립 포인트", value: "2,450", color: "text-purple-600" },
-];
-
 export const transactionData: ProfileTransactionProps[] = [
     { id: 1, name: "럭셔리 시계", date: "2024.01.15", price: "299,000원", imageUrl: "https://readdy.ai/api/search-image?query=elegant%20watch%20luxury%20timepiece%20silver%20metal%20band%20clean%20white%20background%20product%20photography%20professional%20lighting%20high%20quality&width=120&height=120&seq=wishlist001&orientation=squarish" },
     { id: 2, name: "노트북", date: "2024.01.12", price: "1,299,000원", imageUrl: "https://readdy.ai/api/search-image?query=modern%20laptop%20computer%20silver%20aluminum%20design%20clean%20white%20background%20product%20photography%20professional%20lighting%20high%20quality&width=120&height=120&seq=wishlist002&orientation=squarish" },

--- a/frontend/src/features/profile/components/mockData.ts
+++ b/frontend/src/features/profile/components/mockData.ts
@@ -1,6 +1,5 @@
 import type { ProfileBidProps } from "../types/ProfileBidProps";
 import type { ProfileTransactionProps } from "../types/ProfileTransactionProps";
-import type { ProfileStatProps } from "../types/ProfileStatProps";
 
 export const menuData = [
     { icon: "fas fa-shopping-cart", text: "주문/배송 조회", href: "/order" },
@@ -14,7 +13,14 @@ export const bidData: ProfileBidProps[] = [
     { id: 3, name: "스마트폰 케이스", date: "2024.01.10", price: "15,000원", imageUrl: "https://readdy.ai/api/search-image?query=modern%20smartphone%20case%20clear%20transparent%20design%20clean%20white%20background%20product%20photography%20professional%20lighting%20high%20quality&width=60&height=60&seq=product003&orientation=squarish" },
 ];
 
-export const statsData: ProfileStatProps[] = [
+// 레거시 통계 데이터 - 추후 작업에서 온도 데이터로 교체될 예정
+export interface LegacyProfileStatProps {
+    label: string;
+    value: string | number;
+    color: string;
+}
+
+export const statsData: LegacyProfileStatProps[] = [
     { label: "총 주문", value: 12, color: "text-blue-600" },
     { label: "적립 포인트", value: "2,450", color: "text-purple-600" },
 ];

--- a/frontend/src/features/profile/types/ProfileStatProps.ts
+++ b/frontend/src/features/profile/types/ProfileStatProps.ts
@@ -1,5 +1,0 @@
-export interface ProfileStatProps {
-    label: string;
-    value: string | number;
-    color: string;
-}

--- a/frontend/src/features/profile/types/TemperatureCardProps.ts
+++ b/frontend/src/features/profile/types/TemperatureCardProps.ts
@@ -1,0 +1,4 @@
+// 온도 카드 컴포넌트의 props 타입
+export interface TemperatureCardProps {
+    temperature: number; // 사용자 온도 값
+}

--- a/frontend/src/features/user/types/AuthTypes.ts
+++ b/frontend/src/features/user/types/AuthTypes.ts
@@ -14,6 +14,16 @@ export interface AuthUser {
   userType?: string;
   provider?: string;
   requiresNickname?: boolean;
+  temperature?: number; // 사용자 온도 정보
+}
+
+// 완전한 사용자 프로필 정보 (온도 포함)
+export interface UserProfile {
+  userId: number;
+  email: string;
+  nickname: string;
+  userType: string;
+  temperature: number; // 사용자 온도 정보
 }
 
 export interface LoginForm {


### PR DESCRIPTION
**관련 이슈**

- closes #266 

기존 프로필 페이지 상단에 표시되던 '총 주문' 및 '적립 포인트' 정보를 제거하고, 사용자의 실제 **매너 온도**를 API와 연동하여 표시하는 새로운 기능을 추가했습니다.