### PR TITLE
fix(user): 탈퇴 회원 데이터 삭제 시 Wish 엔티티 참조 오류 수정

### DIFF
--- a/backend/demo/src/main/java/com/sesac/solbid/service/user/WithdrawnUserPurgeScheduler.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/user/WithdrawnUserPurgeScheduler.java
@@ -108,8 +108,8 @@ public class WithdrawnUserPurgeScheduler {
         em.createQuery("delete from SocialLogin s where s.user = :u")
                 .setParameter("u", user)
                 .executeUpdate();
-        // WishList 제거
-        em.createQuery("delete from WishList w where w.user = :u")
+        // Wish 제거
+        em.createQuery("delete from Wish w where w.user = :u")
                 .setParameter("u", user)
                 .executeUpdate();
         // Carts 제거


### PR DESCRIPTION
**관련 이슈**

- closes #350 

`WithdrawnUserPurgeScheduler.java` 파일에서 `WishList`를 참조하던 JPQL 쿼리를 `Wish` 엔티티를 참조하도록 수정했습니다.