### PR TITLE
test(user): 사용자 정보에 이름, 연락처 필드 추가

### DIFF
--- a/backend/demo/src/test/java/com/sesac/solbid/controller/AuthControllerTest.java
+++ b/backend/demo/src/test/java/com/sesac/solbid/controller/AuthControllerTest.java
@@ -143,6 +143,8 @@ class AuthControllerTest {
                 1L,
                 "test@gmail.com",
                 "테스트사용자",
+                "테스트이름",
+                "010-1234-5678",
                 UserType.USER,
                 "jwt-access-token",
                 "jwt-refresh-token"
@@ -203,6 +205,8 @@ class AuthControllerTest {
                 2L,
                 "user@kakao.com",
                 "카카오사용자",
+                "카카오이름",
+                "010-9876-5432",
                 UserType.USER,
                 "kakao-jwt-access",
                 "kakao-jwt-refresh"
@@ -588,6 +592,8 @@ class AuthControllerTest {
                 1L,
                 "test@example.com",
                 "테스트",
+                "테스트이름",
+                "010-1111-2222",
                 UserType.USER,
                 "token",
                 "refresh"
@@ -625,6 +631,8 @@ class AuthControllerTest {
                 2L,
                 "kakao@example.com",
                 "카카오",
+                "카카오이름",
+                "010-3333-4444",
                 UserType.USER,
                 "token",
                 "refresh"

--- a/backend/demo/src/test/java/com/sesac/solbid/dto/user/response/LoginResponseJsonTest.java
+++ b/backend/demo/src/test/java/com/sesac/solbid/dto/user/response/LoginResponseJsonTest.java
@@ -20,6 +20,8 @@ class LoginResponseJsonTest {
                 1L, 
                 "test@example.com", 
                 "testuser", 
+                "테스트이름",
+                "010-1234-5678",
                 UserType.USER, 
                 "access-token-123", 
                 "refresh-token-456"
@@ -63,6 +65,8 @@ class LoginResponseJsonTest {
                 2L, 
                 "admin@example.com", 
                 "admin", 
+                "관리자이름",
+                "010-9999-8888",
                 UserType.ADMIN, 
                 "admin-access-token", 
                 "admin-refresh-token"
@@ -85,6 +89,8 @@ class LoginResponseJsonTest {
                 null, 
                 null, 
                 null, 
+                null,
+                null,
                 null
         );
 
@@ -104,6 +110,8 @@ class LoginResponseJsonTest {
                 1L, 
                 "test@example.com", 
                 "testuser", 
+                "테스트이름",
+                "010-5555-6666",
                 UserType.USER, 
                 "access-token-123", 
                 "refresh-token-456"

--- a/backend/demo/src/test/java/com/sesac/solbid/service/RecordDtoServiceCompatibilityTest.java
+++ b/backend/demo/src/test/java/com/sesac/solbid/service/RecordDtoServiceCompatibilityTest.java
@@ -286,6 +286,8 @@ class RecordDtoServiceCompatibilityTest {
                 1L,
                 "test@example.com",
                 "testuser",
+                "테스트이름",
+                "010-7777-8888",
                 UserType.USER,
                 "access-token",
                 "refresh-token"

--- a/backend/demo/src/test/resources/application-test.properties
+++ b/backend/demo/src/test/resources/application-test.properties
@@ -47,6 +47,27 @@ portone.base-url=http://localhost:18080
 portone.api-key=test-api-key
 portone.api-secret=test-api-secret
 
+# Mail configuration for tests (dummy values)
+spring.mail.host=localhost
+spring.mail.port=587
+spring.mail.username=test@example.com
+spring.mail.password=test-password
+spring.mail.properties.mail.smtp.auth=false
+spring.mail.properties.mail.smtp.starttls.enable=false
+
+# Redis configuration for tests (embedded)
+spring.redis.host=localhost
+spring.redis.port=6370
+spring.redis.timeout=2000ms
+
+# AWS configuration for tests
+cloud.aws.region.static=us-east-1
+cloud.aws.credentials.access-key=test-access-key
+cloud.aws.credentials.secret-key=test-secret-key
+
+# Frontend URL for tests
+app.frontend.base-url=http://localhost:3000
+
 # Logging
 logging.level.com.sesac.solbid=INFO
 logging.level.org.springframework.security=INFO


### PR DESCRIPTION
**관련 이슈**

- closes #352 

테스트 코드에 사용자 인증 후 클라이언트에게 반환되는 정보에 사용자의 **실명(name)** 과 **연락처(phone)** 를 추가