### PR TITLE
feat: 경매 카드 실시간 타이머와 입찰 흐름 안정화

### DIFF
--- a/backend/demo/src/main/java/com/sesac/solbid/controller/AuctionEventQueryController.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/controller/AuctionEventQueryController.java
@@ -1,0 +1,33 @@
+package com.sesac.solbid.controller;
+
+import com.sesac.solbid.dto.auction.response.AuctionEventCardResponse;
+import com.sesac.solbid.service.auction.AuctionEventCardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auction-events")
+public class AuctionEventQueryController {
+
+    private final AuctionEventCardService cardService;
+
+    /**
+     * 활성화된 경매 이벤트 카드 조회
+     *
+     * @param limit 조회할 경매 카드의 최대 개수 (1~100, 기본값 30)
+     * @return 활성화된 경매 이벤트를 나타내는 {@link AuctionEventCardResponse} 리스트
+     * */
+    @GetMapping("/cards")
+    public List<AuctionEventCardResponse> list(
+            @RequestParam(name = "limit", defaultValue = "30") int limit
+    ) {
+        int safeLimit = Math.max(1, Math.min(limit, 100));
+        return cardService.fetchActiveCards(safeLimit);
+    }
+}

--- a/backend/demo/src/main/java/com/sesac/solbid/dto/auction/response/AuctionEventCardResponse.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/dto/auction/response/AuctionEventCardResponse.java
@@ -1,0 +1,21 @@
+package com.sesac.solbid.dto.auction.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 경매 카드 리스트 노출용 DTO.
+ * 프론트에서 리스트 렌더링에 필요한 최소 정보를 제공합니다.
+ */
+public record AuctionEventCardResponse(
+        Long auctionEventId,
+        Long productId,
+        String brand,
+        String name,
+        String category,
+        String imageUrl,
+        BigDecimal currentBid,
+        LocalDateTime endAt,
+        int bidders
+) {
+}

--- a/backend/demo/src/main/java/com/sesac/solbid/repository/AuctionEventCardRepository.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/repository/AuctionEventCardRepository.java
@@ -1,0 +1,36 @@
+package com.sesac.solbid.repository;
+
+import com.sesac.solbid.domain.AuctionEvent;
+import com.sesac.solbid.domain.enums.AuctionStatus;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Repository;
+
+import java.util.EnumSet;
+import java.util.List;
+
+@Repository
+public class AuctionEventCardRepository {
+
+    private static final EnumSet<AuctionStatus> DEFAULT_STATUSES = EnumSet.of(
+            AuctionStatus.READY,
+            AuctionStatus.LIVE
+    );
+
+    @PersistenceContext
+    private EntityManager em;
+
+    public List<AuctionEvent> findActiveWithProduct(int limit) {
+        return em.createQuery(
+                        "select distinct a from AuctionEvent a " +
+                                "join fetch a.product p " +
+                                "left join fetch p.productImages imgs " +
+                                "where a.status in :statuses " +
+                                "order by a.endAt asc",
+                        AuctionEvent.class
+                )
+                .setParameter("statuses", DEFAULT_STATUSES)
+                .setMaxResults(limit)
+                .getResultList();
+    }
+}

--- a/backend/demo/src/main/java/com/sesac/solbid/service/auction/AuctionEventCardService.java
+++ b/backend/demo/src/main/java/com/sesac/solbid/service/auction/AuctionEventCardService.java
@@ -1,0 +1,61 @@
+package com.sesac.solbid.service.auction;
+
+import com.sesac.solbid.domain.AuctionEvent;
+import com.sesac.solbid.domain.ProductImage;
+import com.sesac.solbid.dto.auction.response.AuctionEventCardResponse;
+import com.sesac.solbid.repository.AuctionEventCardRepository;
+import com.sesac.solbid.service.s3.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AuctionEventCardService {
+
+    private final AuctionEventCardRepository repository;
+    private final S3Service s3Service;
+
+    private static final Comparator<ProductImage> IMAGE_PRIORITY = Comparator
+            .comparing(ProductImage::isThumbnail, Comparator.reverseOrder())
+            .thenComparing(ProductImage::getSortOrder, Comparator.nullsLast(Integer::compareTo));
+
+    public List<AuctionEventCardResponse> fetchActiveCards(int limit) {
+        return repository.findActiveWithProduct(limit)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private AuctionEventCardResponse toResponse(AuctionEvent event) {
+        var product = event.getProduct();
+
+        String imageUrl = product.getProductImages()
+                .stream()
+                .sorted(IMAGE_PRIORITY)
+                .map(ProductImage::getFilePath)
+                .findFirst()
+                .map(s3Service::presignGetUrl)
+                .orElse(null);
+
+        BigDecimal currentBid = event.getHighestBidAmount();
+        if (currentBid == null) {
+            currentBid = event.getStartPrice();
+        }
+
+        return new AuctionEventCardResponse(
+                event.getAuctionEventId(),
+                product.getProductId(),
+                product.getProductBrand().name(),
+                product.getName(),
+                product.getProductCategory().name(),
+                imageUrl,
+                currentBid,
+                event.getEndAt(),
+                event.getViewCount()
+        );
+    }
+}

--- a/frontend/src/features/auction/components/AuctionItem.tsx
+++ b/frontend/src/features/auction/components/AuctionItem.tsx
@@ -1,12 +1,34 @@
-import {format} from "date-fns";
-import React from "react";
-import type {AuctionItemProps} from "../types/AuctionItemProps";
-import {S3_BASE_URL} from '../../../constants/config';
+import React, { useEffect, useMemo, useState } from "react";
+import type { AuctionItemProps } from "../types/AuctionItemProps";
+import { S3_BASE_URL } from '../../../constants/config';
 
-const AuctionItem = ({item, addWish, removeWish, isAdding, isRemoving, onBidClick}: AuctionItemProps) => {
-    const date = new Date(item.timeLeft);
+function formatRemaining(ms: number) {
+    if (ms <= 0) return '경매 종료';
+    const totalSeconds = Math.floor(ms / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    return [hours, minutes, seconds]
+        .map((unit) => String(unit).padStart(2, '0'))
+        .join(':');
+}
 
-    const timeLeft = format(date, 'HH:mm:ss');
+const AuctionItem = ({ item, addWish, removeWish, isAdding, isRemoving, onBidClick, onSelect }: AuctionItemProps) => {
+    const computeRemaining = useMemo(() => {
+        const endTime = new Date(item.timeLeft).getTime();
+        if (Number.isNaN(endTime)) return () => '-';
+        return () => formatRemaining(endTime - Date.now());
+    }, [item.timeLeft]);
+
+    const [remainingLabel, setRemainingLabel] = useState(computeRemaining());
+
+    useEffect(() => {
+        setRemainingLabel(computeRemaining());
+        const id = window.setInterval(() => {
+            setRemainingLabel(computeRemaining());
+        }, 1000);
+        return () => window.clearInterval(id);
+    }, [computeRemaining]);
 
     const formatter = new Intl.NumberFormat('ko-KR', {
         style: 'currency',
@@ -31,7 +53,18 @@ const AuctionItem = ({item, addWish, removeWish, isAdding, isRemoving, onBidClic
     };
 
     return (
-        <div className="bg-white rounded-lg shadow-sm overflow-hidden hover:shadow-md transition-shadow">
+        <div
+            className="bg-white rounded-lg shadow-sm overflow-hidden hover:shadow-md transition-shadow cursor-pointer"
+            onClick={() => onSelect(item)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onSelect(item);
+                }
+            }}
+        >
             <div className="relative h-64">
                 <img
                     src={item.imageUrl || `${S3_BASE_URL}/${item.image}`}
@@ -39,7 +72,10 @@ const AuctionItem = ({item, addWish, removeWish, isAdding, isRemoving, onBidClic
                     className="w-full h-full object-cover"
                 />
                 <button
-                    onClick={handleClick}
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        handleClick(e);
+                    }}
                     className="absolute top-2 right-2 w-8 h-8 bg-white rounded-full flex items-center justify-center shadow-md hover:bg-red-50 cursor-pointer"
                 >
                     <i className={
@@ -71,7 +107,7 @@ const AuctionItem = ({item, addWish, removeWish, isAdding, isRemoving, onBidClic
                         남은 시간
                     </span>
                     <span className="text-sm font-medium text-red-500">
-                        {timeLeft}
+                        {remainingLabel}
                     </span>
                 </div>
                 <div className="flex items-center justify-between">
@@ -79,7 +115,10 @@ const AuctionItem = ({item, addWish, removeWish, isAdding, isRemoving, onBidClic
                         {item.bidders}명 참여
                     </span>
                     <button
-                        onClick={() => onBidClick(item)}
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            onBidClick(item);
+                        }}
                         className="ml-2 px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 whitespace-nowrap cursor-pointer"
                     >
                         입찰하기

--- a/frontend/src/features/auction/components/AuctionList.tsx
+++ b/frontend/src/features/auction/components/AuctionList.tsx
@@ -1,7 +1,7 @@
 import type { AuctionListProps } from "../types/AuctionListProps";
 import AuctionItem from "./AuctionItem";
 
-const AuctionList = ({ items, onBidClick, addWish, removeWish, isAdding, isRemoving }: AuctionListProps) => {
+const AuctionList = ({ items, onBidClick, onSelect, addWish, removeWish, isAdding, isRemoving }: AuctionListProps) => {
     return (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {items.map(item => (
@@ -13,6 +13,7 @@ const AuctionList = ({ items, onBidClick, addWish, removeWish, isAdding, isRemov
                     isAdding={isAdding}
                     isRemoving={isRemoving}
                     onBidClick={onBidClick}
+                    onSelect={onSelect}
                 />
             ))}
         </div>

--- a/frontend/src/features/auction/hooks/useAuctionEventCards.ts
+++ b/frontend/src/features/auction/hooks/useAuctionEventCards.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchAuctionEventCards } from '../services/auctionEvents';
+import type { AuctionEventCard } from '../types/AuctionEventCard';
+
+const QUERY_KEY = ['auction-event-cards'];
+
+export function useAuctionEventCards(limit = 30) {
+    return useQuery<AuctionEventCard[], Error>({
+        queryKey: [...QUERY_KEY, limit],
+        queryFn: () => fetchAuctionEventCards(limit),
+    });
+}

--- a/frontend/src/features/auction/pages/AuctionDetailPage.tsx
+++ b/frontend/src/features/auction/pages/AuctionDetailPage.tsx
@@ -95,20 +95,16 @@ const AuctionDetailPage: React.FC = () => {
             setBidding(true);
             await AuctionsApi.placeBid(auctionId, amount, idemKey(`bid:${auctionId}`));
 
-            // 낙관적 갱신 (SSE 오기 전 UI 반응)
-            setData((prev) => (prev ? { ...prev, currentPrice: amount, version: (prev.version ?? 0) + 1 } : prev));
-
-            alert("입찰이 완료되었습니다!");
-
             setShowBidModal(false);
             setBidAmount("");
 
-            // 폴백: SSE 누락 대비 강제 동기화
             setTimeout(async () => {
                 try {
                     const fresh = await AuctionsApi.getDetail(auctionId);
                     setData(fresh);
-                } catch {}
+                } catch (syncError) {
+                    console.error(syncError);
+                }
             }, 300);
         } catch (e) {
             console.error(e);

--- a/frontend/src/features/auction/pages/AuctionPage.tsx
+++ b/frontend/src/features/auction/pages/AuctionPage.tsx
@@ -1,13 +1,33 @@
 import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useWishes } from "../../wish/hooks/useWishes.ts";
 import { AuctionList, AuctionModal, AuctionSearch } from "../components";
 import { categories, sortOptions } from "../components/mockData";
-import { useAuctions } from "../hooks/useAuctions.ts";
+import { useAuctionEventCards } from "../hooks/useAuctionEventCards.ts";
 import type { AuctionItem } from "../types/AuctionItem";
 
 const AuctionPage = () => {
-    const { auctions: products, isLoading, isError, error } = useAuctions();
+    const navigate = useNavigate();
+    const { data: cards, isLoading, isError, error } = useAuctionEventCards();
     const { wishes, addWish, removeWish, isAdding, isRemoving } = useWishes();
+
+    const eventIdMap = useMemo(() => new Map(
+        (cards ?? []).map((card) => [card.productId, card.auctionEventId])
+    ), [cards]);
+
+    const products = useMemo<AuctionItem[]>(() => (
+        cards ?? []
+    ).map((card) => ({
+        id: card.productId,
+        brand: card.brand,
+        name: card.name,
+        image: null,
+        imageUrl: card.imageUrl ?? undefined,
+        currentBid: card.currentBid,
+        timeLeft: card.endAt,
+        bidders: card.bidders,
+        category: card.category,
+    })), [cards]);
 
     const wishedIds = useMemo(() => new Set(
         wishes?.map(wish => wish.id) ?? []
@@ -48,20 +68,6 @@ const AuctionPage = () => {
         setIsModalOpen(true);
     };
 
-    // TODO: Refactor this block, Temporarily commented out
-    // const handleBidSubmit = (bidAmount: number) => {
-    //    if (selectedItem) {
-    //        console.log(`Submitted bid: ₩${bidAmount.toLocaleString()} for ${selectedItem.name}`);
-    //        // 실제 API 호출 로직 추가
-    //        const updatedItems = products.map(item =>
-    //            item.id === selectedItem.id
-    //                ? { ...item, currentBid: bidAmount.toLocaleString(), bidders: item.bidders + 1 }
-    //                : item
-    //        );
-    //        setProducts(updatedItems);
-    //    }
-    //};
-
     if (isLoading) {
         return (
             <div className="fixed top-0 left-0 w-full h-full flex justify-center items-center">
@@ -72,7 +78,7 @@ const AuctionPage = () => {
 
     if (isError) {
         return (
-            <div>Error: {error ? error.message : 'An unknown error occurred'}</div>
+            <div>Error: {error?.message ?? 'An unknown error occurred'}</div>
         );
     }
 
@@ -96,6 +102,10 @@ const AuctionPage = () => {
                     isAdding={isAdding}
                     isRemoving={isRemoving}
                     onBidClick={handleBidClick}
+                    onSelect={(item) => {
+                        const targetId = eventIdMap.get(item.id) ?? item.id;
+                        navigate(`/auction/${targetId}`);
+                    }}
                 />
             </main>
             {isModalOpen && selectedItem && (

--- a/frontend/src/features/auction/services/auctionEvents.ts
+++ b/frontend/src/features/auction/services/auctionEvents.ts
@@ -1,0 +1,10 @@
+import { apiFetch } from '../../../utils/apiFetch';
+import type { AuctionEventCard } from '../types/AuctionEventCard';
+
+export async function fetchAuctionEventCards(limit = 30) {
+    const qs = new URLSearchParams();
+    if (limit != null) qs.set('limit', String(limit));
+    const suffix = qs.toString();
+    const url = suffix ? `/api/auction-events/cards?${suffix}` : '/api/auction-events/cards';
+    return apiFetch<AuctionEventCard[]>(url);
+}

--- a/frontend/src/features/auction/services/auctions.ts
+++ b/frontend/src/features/auction/services/auctions.ts
@@ -2,10 +2,7 @@ import { apiFetch } from "../../../utils/http";
 import type { AuctionDetailResponse } from "../types/auctionDetail";
 import type { AuctionCreateRequest, AuctionCreateResponse } from "../types/auction";
 
-// 서버 공통 envelope을 반영한 커스텀 타입
-type BidResponse =
-    | { success: true }
-    | { success: false; data: null; errorCode?: string; message?: string };
+type BidResponse = { success: true } | { success: false; message?: string };
 
 export const AuctionsApi = {
     getDetail(auctionId: number) {
@@ -18,11 +15,13 @@ export const AuctionsApi = {
             headers: { "X-Idempotent-Key": idempotencyKey },
             body: { amount, idempotencyKey },
         });
-        if (!res.success) {
-            // 서버가 200이어도 success:false면 에러로 처리
-            throw new Error(res.message || "입찰에 실패했습니다.");
-        }
-        return res;
+
+        if (res?.success === true) return true;
+
+        const message = res && "message" in res && typeof res.message === "string"
+            ? res.message
+            : "입찰에 실패했습니다.";
+        throw new Error(message);
     },
 
     create(payload: AuctionCreateRequest) {

--- a/frontend/src/features/auction/types/AuctionEventCard.ts
+++ b/frontend/src/features/auction/types/AuctionEventCard.ts
@@ -1,0 +1,11 @@
+export interface AuctionEventCard {
+    auctionEventId: number;
+    productId: number;
+    brand: string;
+    name: string;
+    category: string;
+    imageUrl: string | null;
+    currentBid: number;
+    endAt: string; // ISO string
+    bidders: number;
+}

--- a/frontend/src/features/auction/types/AuctionItemProps.ts
+++ b/frontend/src/features/auction/types/AuctionItemProps.ts
@@ -4,6 +4,7 @@ import type { AuctionItem } from "./AuctionItem";
 export interface AuctionItemProps {
     item: AuctionItem;
     onBidClick: (item: AuctionItem) => void;
+    onSelect: (item: AuctionItem) => void;
     addWish: (item: Wish) => void;
     removeWish: (id: number) => void;
     isAdding: boolean;

--- a/frontend/src/features/auction/types/AuctionListProps.ts
+++ b/frontend/src/features/auction/types/AuctionListProps.ts
@@ -4,6 +4,7 @@ import type { AuctionItem } from "./AuctionItem";
 export interface AuctionListProps {
     items: AuctionItem[];
     onBidClick: (item: AuctionItem) => void;
+    onSelect: (item: AuctionItem) => void;
     addWish: (item: Wish) => void;
     removeWish: (id: number) => void;
     isAdding: boolean;


### PR DESCRIPTION
  - 경매 이벤트 카드 전용 API(컨트롤러·서비스·레포지토리·DTO) 추가
  - 목록 페이지를 새 카드 데이터로 전환하고 auctionEventId 기반 이동 적용
  - 경매 카드에 남은 시간을 실시간 카운트다운으로 표시
  - 입찰 API 응답을 명확히 검증해 성공 시에만 UI 갱신하고 중복 알림 방지

close #369